### PR TITLE
Build interactive dispatching workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
-# Tow-Truck-System
+# Towbook Cloud Dispatch Dashboard
+
+This project provides a responsive, cloud-inspired dashboard for a towing and impound management platform. The UI mirrors the Towbook sample provided and includes:
+
+- Company dispatch overview metrics with live status counts
+- A live dispatch board with filtering and refresh simulation
+- Impound yard snapshot and reporting cards for operations insights
+- A fully interactive dispatching workspace with call management, driver messaging, and survey operations
+
+## Getting Started
+
+1. Start a local web server from the repository root (for example with Python):
+   ```bash
+   python -m http.server 8000
+   ```
+2. Visit [http://localhost:8000](http://localhost:8000) in your browser to view the dashboard.
+
+All assets are static (HTML, CSS, and JavaScript) and require no additional build steps.
+
+## Dispatching Workspace
+
+Navigate to the **Dispatching** tab to access the operational console:
+
+- **View Calls** &mdash; filter calls by customer, vehicle, zone, personnel, or date range. Counts and status summaries update instantly as you apply filters.
+- **Driver Messaging** &mdash; select a driver to review the live conversation stream and send real-time updates. Unread indicators clear automatically once you open a thread.
+- **Surveys** &mdash; manage customer, driver, and vendor surveys with status toggles and filtering controls.
+
+Use the **New Dispatch** button on the dashboard header to jump directly into the dispatching workflow.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,351 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Towbook | Cloud Dispatch Platform</title>
+    <link rel="stylesheet" href="styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <div class="app-shell">
+      <header class="topbar">
+        <div class="brand">towbook<span class="brand-cloud">cloud</span></div>
+        <nav class="primary-nav">
+          <a class="nav-link active" href="#" data-view-target="dashboard">Dashboard</a>
+          <a class="nav-link" href="#" data-view-target="dispatching">Dispatching</a>
+          <a class="nav-link" href="#" data-view-target="impounds">Impounds</a>
+          <a class="nav-link" href="#" data-view-target="accounts">Accounts</a>
+          <a class="nav-link" href="#" data-view-target="reports">Reports</a>
+          <a class="nav-link" href="#" data-view-target="settings">Settings</a>
+        </nav>
+        <div class="user-meta">
+          <span class="support">Need help? <strong>Contact Towbook Cloud</strong></span>
+          <div class="user-info">
+            <div class="user-name">Tsedeke Girma</div>
+            <div class="user-role">Dispatcher</div>
+          </div>
+          <div class="user-status">Online</div>
+        </div>
+      </header>
+
+      <main class="view dashboard-view" data-view="dashboard">
+        <section class="welcome-card">
+          <div>
+            <h1>Good morning, <span>Tsedeke Girma</span>.</h1>
+            <p>Welcome to Towbook Cloud! Here's what's happening with your fleet.</p>
+          </div>
+          <button class="primary-action" id="go-to-dispatch">New Dispatch</button>
+        </section>
+
+        <section class="dispatch-overview" aria-labelledby="dispatch-overview-heading">
+          <div class="section-heading">
+            <h2 id="dispatch-overview-heading">Company Dispatch Overview</h2>
+            <div class="meta">Last updated at <span class="update-time">7:52:55 AM</span></div>
+          </div>
+          <div class="metric-grid" id="status-metrics"></div>
+        </section>
+
+        <section class="live-board" id="dashboard-dispatching">
+          <header class="section-heading">
+            <h2>Live Dispatch Board</h2>
+            <div class="controls">
+              <label class="filter">
+                <span>Status</span>
+                <select id="status-filter">
+                  <option value="all">All</option>
+                  <option value="waiting">Waiting</option>
+                  <option value="dispatched">Dispatched</option>
+                  <option value="enroute">En Route</option>
+                  <option value="onscene">On Scene</option>
+                  <option value="towing">Towing</option>
+                  <option value="completed">Completed</option>
+                  <option value="canceled">Canceled</option>
+                </select>
+              </label>
+              <button class="secondary-action" id="refresh-board">Refresh</button>
+            </div>
+          </header>
+          <div class="board-content">
+            <table class="data-table" aria-describedby="dashboard-dispatching">
+              <thead>
+                <tr>
+                  <th>Ticket</th>
+                  <th>Customer</th>
+                  <th>Vehicle</th>
+                  <th>Location</th>
+                  <th>Driver</th>
+                  <th>Status</th>
+                  <th>ETA</th>
+                </tr>
+              </thead>
+              <tbody id="dashboard-dispatch-rows"></tbody>
+            </table>
+          </div>
+        </section>
+
+        <div class="grid-panels">
+          <section class="panel" id="impounds">
+            <header class="section-heading">
+              <h2>Impound Yard Snapshot</h2>
+              <a class="link" href="#">View All</a>
+            </header>
+            <ul class="impound-list" id="impound-list"></ul>
+          </section>
+
+          <section class="panel" id="reports">
+            <header class="section-heading">
+              <h2>Analytics &amp; Reporting</h2>
+              <a class="link" href="#">Generate Report</a>
+            </header>
+            <div class="reports">
+              <article class="report-card">
+                <h3>Revenue This Month</h3>
+                <p class="highlight" id="report-revenue"></p>
+                <p class="trend positive">▲ 12% vs last month</p>
+              </article>
+              <article class="report-card">
+                <h3>Average Response Time</h3>
+                <p class="highlight" id="report-response"></p>
+                <p class="trend negative">▼ 4% vs last week</p>
+              </article>
+              <article class="report-card">
+                <h3>Active Contracts</h3>
+                <p class="highlight" id="report-contracts"></p>
+                <p class="trend stable">■ No change</p>
+              </article>
+            </div>
+          </section>
+        </div>
+      </main>
+
+      <main class="view dispatch-view" data-view="dispatching" hidden>
+        <section class="dispatch-hero">
+          <div>
+            <h1>Dispatching Center</h1>
+            <p>Coordinate calls, drivers, and customer feedback in real time.</p>
+          </div>
+          <div class="dispatch-meta" role="status" aria-live="polite">
+            <div class="meta-block">
+              <span class="meta-label">Shift</span>
+              <span class="meta-value">Morning · 7:00a – 3:00p</span>
+            </div>
+            <div class="meta-block">
+              <span class="meta-label">Live Calls</span>
+              <span class="meta-value" id="live-call-count">0</span>
+            </div>
+          </div>
+        </section>
+
+        <nav class="dispatch-tabs" role="tablist">
+          <button
+            class="dispatch-tab active"
+            type="button"
+            role="tab"
+            aria-selected="true"
+            data-dispatch-tab="view-calls"
+          >
+            View Calls
+          </button>
+          <button
+            class="dispatch-tab"
+            type="button"
+            role="tab"
+            aria-selected="false"
+            data-dispatch-tab="driver-messaging"
+          >
+            Driver Messaging
+          </button>
+          <button
+            class="dispatch-tab"
+            type="button"
+            role="tab"
+            aria-selected="false"
+            data-dispatch-tab="surveys"
+          >
+            Surveys
+          </button>
+        </nav>
+
+        <section class="dispatch-panel" data-dispatch-panel="view-calls">
+          <form class="dispatch-filters" id="dispatch-filter-form">
+            <div class="form-field">
+              <label for="filter-customer">Customer</label>
+              <input id="filter-customer" name="customer" type="text" placeholder="Search customer" />
+            </div>
+            <div class="form-field">
+              <label for="filter-vehicle">Vehicle</label>
+              <input id="filter-vehicle" name="vehicle" type="text" placeholder="Plate, make or model" />
+            </div>
+            <div class="form-field">
+              <label for="filter-driver">Driver / Dispatcher</label>
+              <select id="filter-driver" name="driver">
+                <option value="">All personnel</option>
+              </select>
+            </div>
+            <div class="form-field">
+              <label for="filter-zone">Zone</label>
+              <select id="filter-zone" name="zone">
+                <option value="">All zones</option>
+              </select>
+            </div>
+            <div class="form-field date-range">
+              <label for="filter-start">Date Range</label>
+              <div class="date-inputs">
+                <input id="filter-start" name="startDate" type="date" />
+                <span aria-hidden="true">to</span>
+                <input id="filter-end" name="endDate" type="date" />
+              </div>
+            </div>
+            <div class="form-actions">
+              <button type="submit" class="primary-action">Get Results</button>
+              <button type="reset" class="secondary-action">Cancel</button>
+            </div>
+          </form>
+
+          <div class="call-summary" id="call-summary" aria-live="polite"></div>
+
+          <div class="call-sections">
+            <article class="call-panel" data-call-section="active">
+              <header class="panel-header">
+                <h2>Active Calls</h2>
+                <span class="badge" data-call-count="active">0</span>
+              </header>
+              <table class="data-table">
+                <thead>
+                  <tr>
+                    <th>Call #</th>
+                    <th>Customer</th>
+                    <th>Vehicle</th>
+                    <th>Zone</th>
+                    <th>Driver</th>
+                    <th>Dispatcher</th>
+                    <th>Opened</th>
+                    <th>Status</th>
+                    <th>ETA</th>
+                  </tr>
+                </thead>
+                <tbody data-call-body="active"></tbody>
+              </table>
+            </article>
+
+            <article class="call-panel" data-call-section="canceled">
+              <header class="panel-header">
+                <h2>Canceled</h2>
+                <span class="badge" data-call-count="canceled">0</span>
+              </header>
+              <table class="data-table">
+                <thead>
+                  <tr>
+                    <th>Call #</th>
+                    <th>Customer</th>
+                    <th>Reason</th>
+                    <th>Dispatcher</th>
+                    <th>Updated</th>
+                  </tr>
+                </thead>
+                <tbody data-call-body="canceled"></tbody>
+              </table>
+            </article>
+
+            <article class="call-panel" data-call-section="queued">
+              <header class="panel-header">
+                <h2>Queued</h2>
+                <span class="badge" data-call-count="queued">0</span>
+              </header>
+              <table class="data-table">
+                <thead>
+                  <tr>
+                    <th>Call #</th>
+                    <th>Customer</th>
+                    <th>Vehicle</th>
+                    <th>Requested</th>
+                    <th>Scheduled</th>
+                    <th>Zone</th>
+                    <th>Notes</th>
+                  </tr>
+                </thead>
+                <tbody data-call-body="queued"></tbody>
+              </table>
+            </article>
+          </div>
+        </section>
+
+        <section class="dispatch-panel" data-dispatch-panel="driver-messaging" hidden>
+          <div class="messaging-layout">
+            <aside class="messaging-roster" id="messaging-roster" role="tablist"></aside>
+            <div class="messaging-thread" role="tabpanel">
+              <header class="thread-header">
+                <div class="thread-title" id="active-thread-name">Select a driver</div>
+                <div class="thread-status" id="active-thread-status"></div>
+              </header>
+              <div class="message-log" id="message-log" aria-live="polite"></div>
+              <form id="message-form" class="message-form">
+                <label class="sr-only" for="message-input">Message</label>
+                <textarea
+                  id="message-input"
+                  name="message"
+                  rows="2"
+                  placeholder="Type a message to the selected driver..."
+                  required
+                ></textarea>
+                <div class="form-actions">
+                  <button type="submit" class="primary-action">Send</button>
+                  <button type="button" class="secondary-action" id="mark-thread-read">Mark as Read</button>
+                </div>
+              </form>
+            </div>
+          </div>
+        </section>
+
+        <section class="dispatch-panel" data-dispatch-panel="surveys" hidden>
+          <form class="survey-filters" id="survey-filter-form">
+            <div class="form-field">
+              <label for="survey-category">Category</label>
+              <select id="survey-category" name="category">
+                <option value="all">All categories</option>
+                <option value="customer">Customer</option>
+                <option value="driver">Driver</option>
+                <option value="vendor">Vendor</option>
+              </select>
+            </div>
+            <div class="form-field">
+              <label for="survey-status">Status</label>
+              <select id="survey-status" name="status">
+                <option value="all">All statuses</option>
+                <option value="active">Active</option>
+                <option value="scheduled">Scheduled</option>
+                <option value="paused">Paused</option>
+              </select>
+            </div>
+            <div class="form-field">
+              <label for="survey-search">Keyword</label>
+              <input id="survey-search" name="search" type="search" placeholder="Search surveys" />
+            </div>
+            <div class="form-actions">
+              <button type="submit" class="primary-action">Apply Filters</button>
+              <button type="reset" class="secondary-action">Clear</button>
+            </div>
+          </form>
+          <div class="survey-list" id="survey-list" role="list"></div>
+        </section>
+      </main>
+
+      <footer class="footer">
+        <div>© 2024 Towbook Cloud. All rights reserved.</div>
+        <div class="footer-links">
+          <a href="#">Status</a>
+          <a href="#">Privacy</a>
+          <a href="#">Support</a>
+        </div>
+      </footer>
+    </div>
+
+    <script src="script.js" type="module"></script>
+  </body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,1204 @@
+const dashboardStatusMetricsEl = document.querySelector('#status-metrics');
+const dashboardDispatchRowsEl = document.querySelector('#dashboard-dispatch-rows');
+const impoundListEl = document.querySelector('#impound-list');
+const statusFilterEl = document.querySelector('#status-filter');
+const refreshBoardButton = document.querySelector('#refresh-board');
+const goToDispatchButton = document.querySelector('#go-to-dispatch');
+
+const navLinks = document.querySelectorAll('.nav-link[data-view-target]');
+const views = document.querySelectorAll('.view[data-view]');
+
+const dispatchFilterForm = document.querySelector('#dispatch-filter-form');
+const dispatchDriverFilterEl = document.querySelector('#filter-driver');
+const dispatchZoneFilterEl = document.querySelector('#filter-zone');
+const callSummaryEl = document.querySelector('#call-summary');
+const callCountBadges = document.querySelectorAll('[data-call-count]');
+const callTableBodies = {
+  active: document.querySelector('[data-call-body="active"]'),
+  canceled: document.querySelector('[data-call-body="canceled"]'),
+  queued: document.querySelector('[data-call-body="queued"]')
+};
+const liveCallCountEl = document.querySelector('#live-call-count');
+
+const dispatchTabs = document.querySelectorAll('.dispatch-tab');
+const dispatchPanels = document.querySelectorAll('.dispatch-panel');
+
+const messagingRosterEl = document.querySelector('#messaging-roster');
+const messageLogEl = document.querySelector('#message-log');
+const messageFormEl = document.querySelector('#message-form');
+const messageInputEl = document.querySelector('#message-input');
+const markThreadReadButton = document.querySelector('#mark-thread-read');
+const messageSubmitButton = messageFormEl?.querySelector('button[type="submit"]');
+const activeThreadNameEl = document.querySelector('#active-thread-name');
+const activeThreadStatusEl = document.querySelector('#active-thread-status');
+
+const surveyFilterForm = document.querySelector('#survey-filter-form');
+const surveyListEl = document.querySelector('#survey-list');
+
+const statusLabels = {
+  waiting: 'Waiting',
+  dispatched: 'Dispatched',
+  enroute: 'En Route',
+  onscene: 'On Scene',
+  towing: 'Towing',
+  completed: 'Completed',
+  canceled: 'Canceled'
+};
+
+const dashboardDispatchMetrics = [
+  { key: 'waiting', label: statusLabels.waiting, count: 8, subtext: 'Open calls awaiting dispatch' },
+  { key: 'dispatched', label: statusLabels.dispatched, count: 5, subtext: 'Drivers acknowledged' },
+  { key: 'enroute', label: statusLabels.enroute, count: 3, subtext: 'Drivers headed to scene' },
+  { key: 'onscene', label: statusLabels.onscene, count: 2, subtext: 'Vehicles secured' },
+  { key: 'towing', label: statusLabels.towing, count: 4, subtext: 'In transit to destination' },
+  { key: 'completed', label: statusLabels.completed, count: 16, subtext: 'Finished in last 24h' },
+  { key: 'canceled', label: statusLabels.canceled, count: 1, subtext: 'Canceled in last 24h' }
+];
+
+const dashboardDispatchTickets = [
+  {
+    id: 'TB-1045',
+    customer: 'Samantha Lee',
+    vehicle: '2019 Toyota Camry',
+    location: 'I-94 Exit 23',
+    driver: 'Ralph Simmons',
+    status: 'waiting',
+    eta: '10 min'
+  },
+  {
+    id: 'TB-1042',
+    customer: 'City Parking Enforcement',
+    vehicle: '2015 Ford F-150',
+    location: 'Downtown Lot C',
+    driver: 'Marta Diaz',
+    status: 'dispatched',
+    eta: 'Driver En Route'
+  },
+  {
+    id: 'TB-1039',
+    customer: 'Erik Nelson',
+    vehicle: '2022 Tesla Model 3',
+    location: 'Grand Ave & 5th',
+    driver: 'Jordan Blake',
+    status: 'enroute',
+    eta: '5 min'
+  },
+  {
+    id: 'TB-1035',
+    customer: 'Metro Police',
+    vehicle: '2010 Honda Civic',
+    location: 'Precinct 7',
+    driver: 'Ralph Simmons',
+    status: 'onscene',
+    eta: 'Securing'
+  },
+  {
+    id: 'TB-1033',
+    customer: 'AAA Motor Club',
+    vehicle: '2016 Jeep Wrangler',
+    location: 'County Rd 12',
+    driver: 'Amelia Cross',
+    status: 'towing',
+    eta: '30 min'
+  },
+  {
+    id: 'TB-1028',
+    customer: 'Allied Insurance',
+    vehicle: '2018 BMW X5',
+    location: 'Service Center',
+    driver: 'Luka Petrović',
+    status: 'completed',
+    eta: 'Delivered'
+  },
+  {
+    id: 'TB-1026',
+    customer: 'Private Property Impound',
+    vehicle: '2008 Chevy Malibu',
+    location: 'Lot 42A',
+    driver: 'Marta Diaz',
+    status: 'canceled',
+    eta: 'N/A'
+  }
+];
+
+const impoundVehicles = [
+  {
+    title: 'INV-8841 · Ford Transit',
+    owner: 'City Maintenance',
+    holdReason: 'Expired permits',
+    releaseDate: 'Pending'
+  },
+  {
+    title: 'INV-8823 · Dodge Charger',
+    owner: 'Leonard Jackson',
+    holdReason: 'Police hold',
+    releaseDate: 'Review 10/01'
+  },
+  {
+    title: 'INV-8810 · Toyota Prius',
+    owner: 'EcoRide Rentals',
+    holdReason: 'Awaiting payment',
+    releaseDate: 'Due 09/30'
+  }
+];
+
+const reportingMetrics = {
+  revenue: '$48,230',
+  responseTime: '22m 14s',
+  activeContracts: '34'
+};
+
+const callProgressMeta = {
+  new: {
+    label: 'New Calls',
+    description: 'Logged in the last hour',
+    accent: 'accent-new'
+  },
+  waiting: {
+    label: 'Waiting',
+    description: 'Driver acknowledged and en route',
+    accent: 'accent-waiting'
+  },
+  destination: {
+    label: 'Destination Arrived',
+    description: 'Vehicle at drop-off location',
+    accent: 'accent-destination'
+  },
+  completed: {
+    label: 'Completed',
+    description: 'Delivered to destination',
+    accent: 'accent-completed'
+  },
+  canceled: {
+    label: 'Canceled',
+    description: 'Canceled by customer or dispatcher',
+    accent: 'accent-canceled'
+  },
+  queued: {
+    label: 'Queued',
+    description: 'Awaiting scheduling window',
+    accent: 'accent-queued'
+  }
+};
+
+const dispatchCalls = [
+  {
+    id: 'TB-2078',
+    customer: 'City of Detroit PD',
+    vehicle: '2018 Ford Explorer · Unit 42',
+    location: 'Mack Ave & Alter Rd',
+    driver: 'Ralph Simmons',
+    dispatcher: 'Tsedeke Girma',
+    zone: 'East',
+    status: 'active',
+    progress: 'waiting',
+    openedAt: '2024-09-30T07:45:00',
+    updatedAt: '2024-09-30T08:24:00',
+    eta: '12 min',
+    incidentType: 'Police Tow',
+    notes: 'Driver confirmed arrival in 12 minutes.'
+  },
+  {
+    id: 'TB-2081',
+    customer: 'Allied Insurance',
+    vehicle: '2022 Tesla Model Y',
+    location: 'Grand Circus Park Garage',
+    driver: 'Amelia Cross',
+    dispatcher: 'Tsedeke Girma',
+    zone: 'Central',
+    status: 'active',
+    progress: 'new',
+    openedAt: '2024-09-30T08:10:00',
+    updatedAt: '2024-09-30T08:18:00',
+    eta: 'Assign driver',
+    incidentType: 'Accident',
+    notes: 'Need flatbed, waiting on driver confirmation.'
+  },
+  {
+    id: 'TB-2072',
+    customer: 'AAA Motor Club',
+    vehicle: '2017 Honda Accord',
+    location: 'I-75 Exit 32',
+    driver: 'Jordan Blake',
+    dispatcher: 'Morgan Wu',
+    zone: 'South',
+    status: 'active',
+    progress: 'destination',
+    openedAt: '2024-09-30T06:58:00',
+    updatedAt: '2024-09-30T08:12:00',
+    eta: 'Arrived',
+    incidentType: 'Breakdown',
+    notes: 'Drop-off at Lakeside Service complete.'
+  },
+  {
+    id: 'TB-2066',
+    customer: 'City Parking Enforcement',
+    vehicle: '2009 Ford Econoline',
+    location: 'Downtown Lot C',
+    driver: 'Marta Diaz',
+    dispatcher: 'Morgan Wu',
+    zone: 'Central',
+    status: 'canceled',
+    progress: 'canceled',
+    openedAt: '2024-09-29T22:10:00',
+    updatedAt: '2024-09-30T07:20:00',
+    eta: 'N/A',
+    incidentType: 'Impound',
+    notes: 'Canceled by enforcement due to duplicate entry.',
+    reason: 'Duplicate request from partner portal.'
+  },
+  {
+    id: 'TB-2075',
+    customer: 'Private Property Impound',
+    vehicle: '2011 Chevy Silverado',
+    location: 'Lot 42A',
+    driver: 'Luka Petrović',
+    dispatcher: 'Morgan Wu',
+    zone: 'West',
+    status: 'queued',
+    progress: 'queued',
+    openedAt: '2024-09-30T06:15:00',
+    updatedAt: '2024-09-30T06:45:00',
+    eta: 'Scheduled 09:30 AM',
+    incidentType: 'Private Property',
+    notes: 'Hold until tenant notification complete.',
+    requestedAt: '2024-09-30T06:12:00',
+    scheduledFor: '2024-09-30T09:30:00'
+  },
+  {
+    id: 'TB-2069',
+    customer: 'City of Detroit DPW',
+    vehicle: '2016 Freightliner Dump Truck',
+    location: 'Jefferson & Mt. Elliott',
+    driver: 'Ralph Simmons',
+    dispatcher: 'Tsedeke Girma',
+    zone: 'East',
+    status: 'active',
+    progress: 'waiting',
+    openedAt: '2024-09-30T07:05:00',
+    updatedAt: '2024-09-30T08:02:00',
+    eta: '18 min',
+    incidentType: 'Equipment Failure',
+    notes: 'Awaiting police clearance for tow route.'
+  },
+  {
+    id: 'TB-2059',
+    customer: 'Metro Police',
+    vehicle: '2014 Dodge Charger',
+    location: 'Precinct 7',
+    driver: 'Jordan Blake',
+    dispatcher: 'Morgan Wu',
+    zone: 'North',
+    status: 'active',
+    progress: 'completed',
+    openedAt: '2024-09-29T23:58:00',
+    updatedAt: '2024-09-30T07:55:00',
+    eta: 'Completed',
+    incidentType: 'Evidence Hold',
+    notes: 'Vehicle secured in impound yard #3.'
+  },
+  {
+    id: 'TB-2082',
+    customer: 'Quick Tow Partners',
+    vehicle: '2015 Ford F-150',
+    location: 'Livernois & W 7 Mile',
+    driver: 'Pending Assignment',
+    dispatcher: 'Tsedeke Girma',
+    zone: 'West',
+    status: 'queued',
+    progress: 'queued',
+    openedAt: '2024-09-30T08:20:00',
+    updatedAt: '2024-09-30T08:20:00',
+    eta: 'Needs assignment',
+    incidentType: 'Partner Transfer',
+    notes: 'Awaiting confirmation from partner network.',
+    requestedAt: '2024-09-30T08:18:00',
+    scheduledFor: '2024-09-30T09:00:00'
+  },
+  {
+    id: 'TB-2068',
+    customer: 'Evergreen Insurance',
+    vehicle: '2020 Subaru Outback',
+    location: 'I-96 Service Dr',
+    driver: 'Amelia Cross',
+    dispatcher: 'Morgan Wu',
+    zone: 'North',
+    status: 'active',
+    progress: 'waiting',
+    openedAt: '2024-09-30T07:18:00',
+    updatedAt: '2024-09-30T08:11:00',
+    eta: '15 min',
+    incidentType: 'Breakdown',
+    notes: 'Flat tire. Customer riding with driver.'
+  },
+  {
+    id: 'TB-2051',
+    customer: 'Customer Walk-in',
+    vehicle: '2008 Toyota Corolla',
+    location: 'Yard Intake',
+    driver: 'Warehouse Team',
+    dispatcher: 'Morgan Wu',
+    zone: 'Central',
+    status: 'canceled',
+    progress: 'canceled',
+    openedAt: '2024-09-29T18:10:00',
+    updatedAt: '2024-09-29T19:30:00',
+    eta: 'N/A',
+    incidentType: 'Release',
+    notes: 'Customer picked up before dispatch.',
+    reason: 'Walk-in release prior to dispatch.'
+  }
+];
+
+const driverProfiles = [
+  {
+    id: 'driver-ralph-simmons',
+    name: 'Ralph Simmons',
+    unit: 'Unit 12 · Heavy Duty',
+    zone: 'East',
+    status: 'On Scene',
+    lastActive: '08:26 AM',
+    messages: [
+      { id: 'm1', from: 'driver', body: 'Arrived at Mack & Alter. Setting up safety cones.', timestamp: '08:21 AM', read: false },
+      { id: 'm2', from: 'dispatcher', body: 'Copy. Let me know when vehicle is secured.', timestamp: '08:22 AM', read: true }
+    ]
+  },
+  {
+    id: 'driver-amelia-cross',
+    name: 'Amelia Cross',
+    unit: 'Unit 7 · Flatbed',
+    zone: 'Central',
+    status: 'En Route',
+    lastActive: '08:18 AM',
+    messages: [
+      { id: 'm3', from: 'dispatcher', body: 'Need your status on Tesla Model Y.', timestamp: '08:15 AM', read: true },
+      { id: 'm4', from: 'driver', body: 'Waiting on clearance to enter garage.', timestamp: '08:17 AM', read: false }
+    ]
+  },
+  {
+    id: 'driver-jordan-blake',
+    name: 'Jordan Blake',
+    unit: 'Unit 4 · Wrecker',
+    zone: 'South',
+    status: 'Drop-off',
+    lastActive: '08:12 AM',
+    messages: [
+      { id: 'm5', from: 'driver', body: 'Arrived at Lakeside Service. Completing paperwork.', timestamp: '08:11 AM', read: false }
+    ]
+  },
+  {
+    id: 'driver-marta-diaz',
+    name: 'Marta Diaz',
+    unit: 'Unit 9 · Wheel Lift',
+    zone: 'Central',
+    status: 'Standby',
+    lastActive: '08:07 AM',
+    messages: [
+      { id: 'm6', from: 'dispatcher', body: 'Hold position until further notice.', timestamp: '07:55 AM', read: true }
+    ]
+  }
+];
+
+const surveyTemplates = [
+  {
+    id: 'survey-cust-01',
+    title: 'Customer Tow Satisfaction',
+    category: 'customer',
+    status: 'active',
+    lastSent: '2024-09-29',
+    responses: 42,
+    completionRate: 0.78
+  },
+  {
+    id: 'survey-driver-01',
+    title: 'Driver Daily Checklist',
+    category: 'driver',
+    status: 'scheduled',
+    lastSent: '2024-09-28',
+    responses: 24,
+    completionRate: 0.92
+  },
+  {
+    id: 'survey-vendor-01',
+    title: 'Body Shop Partner Feedback',
+    category: 'vendor',
+    status: 'paused',
+    lastSent: '2024-09-15',
+    responses: 12,
+    completionRate: 0.54
+  },
+  {
+    id: 'survey-cust-02',
+    title: 'Roadside Assistance Follow-up',
+    category: 'customer',
+    status: 'active',
+    lastSent: '2024-09-30',
+    responses: 65,
+    completionRate: 0.83
+  },
+  {
+    id: 'survey-driver-02',
+    title: 'Driver Equipment Audit',
+    category: 'driver',
+    status: 'paused',
+    lastSent: '2024-09-10',
+    responses: 18,
+    completionRate: 0.61
+  }
+];
+
+let currentDispatchFilters = {
+  customer: '',
+  vehicle: '',
+  driver: '',
+  zone: '',
+  startDate: null,
+  endDate: null
+};
+
+let activeDispatchTab = 'view-calls';
+let activeDriverId = null;
+let surveyFilters = {
+  category: 'all',
+  status: 'all',
+  search: ''
+};
+
+function generateMessageId() {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return `msg-${Date.now()}-${Math.random().toString(16).slice(2, 10)}`;
+}
+
+function setActiveView(target) {
+  const targetView = Array.from(views).find((view) => view.dataset.view === target);
+  if (!targetView) {
+    return;
+  }
+
+  views.forEach((view) => {
+    view.hidden = view !== targetView;
+  });
+
+  navLinks.forEach((link) => {
+    const isActive = link.dataset.viewTarget === target;
+    link.classList.toggle('active', isActive);
+    link.setAttribute('aria-current', isActive ? 'page' : 'false');
+  });
+}
+
+function renderDashboardMetrics() {
+  if (!dashboardStatusMetricsEl) return;
+
+  const fragment = document.createDocumentFragment();
+  dashboardDispatchMetrics.forEach(({ label, count, subtext }) => {
+    const card = document.createElement('article');
+    card.className = 'metric-card';
+    card.innerHTML = `
+      <div class="metric-title">${label}</div>
+      <div class="metric-value">${count}</div>
+      <div class="metric-subtext">${subtext}</div>
+    `;
+    fragment.appendChild(card);
+  });
+  dashboardStatusMetricsEl.appendChild(fragment);
+}
+
+function renderDashboardDispatchRows(filter = 'all') {
+  if (!dashboardDispatchRowsEl) return;
+
+  dashboardDispatchRowsEl.innerHTML = '';
+  const fragment = document.createDocumentFragment();
+
+  dashboardDispatchTickets
+    .filter((ticket) => filter === 'all' || ticket.status === filter)
+    .forEach((ticket) => {
+      const row = document.createElement('tr');
+      row.innerHTML = `
+        <td>${ticket.id}</td>
+        <td>${ticket.customer}</td>
+        <td>${ticket.vehicle}</td>
+        <td>${ticket.location}</td>
+        <td>${ticket.driver}</td>
+        <td><span class="status-chip status-${ticket.status}">${statusLabels[ticket.status] ?? ticket.status}</span></td>
+        <td>${ticket.eta}</td>
+      `;
+      fragment.appendChild(row);
+    });
+
+  if (!fragment.children.length) {
+    const emptyRow = document.createElement('tr');
+    emptyRow.innerHTML = '<td colspan="7" class="empty">No tickets match the selected status.</td>';
+    fragment.appendChild(emptyRow);
+  }
+
+  dashboardDispatchRowsEl.appendChild(fragment);
+}
+
+function renderImpounds() {
+  if (!impoundListEl) return;
+
+  const fragment = document.createDocumentFragment();
+  impoundVehicles.forEach(({ title, owner, holdReason, releaseDate }) => {
+    const item = document.createElement('li');
+    item.className = 'impound-item';
+    item.innerHTML = `
+      <h3>${title}</h3>
+      <span>Owner: ${owner}</span>
+      <span>Hold Reason: ${holdReason}</span>
+      <span>Release: ${releaseDate}</span>
+    `;
+    fragment.appendChild(item);
+  });
+  impoundListEl.appendChild(fragment);
+}
+
+function renderReports() {
+  const revenueEl = document.querySelector('#report-revenue');
+  const responseEl = document.querySelector('#report-response');
+  const contractsEl = document.querySelector('#report-contracts');
+
+  if (revenueEl) revenueEl.textContent = reportingMetrics.revenue;
+  if (responseEl) responseEl.textContent = reportingMetrics.responseTime;
+  if (contractsEl) contractsEl.textContent = reportingMetrics.activeContracts;
+}
+
+function populateDispatchFilters() {
+  if (!dispatchDriverFilterEl || !dispatchZoneFilterEl) return;
+
+  const personnel = new Set();
+  const zones = new Set();
+
+  dispatchCalls.forEach((call) => {
+    if (call.driver) personnel.add(call.driver);
+    if (call.dispatcher) personnel.add(call.dispatcher);
+    if (call.zone) zones.add(call.zone);
+  });
+
+  const sortedPersonnel = Array.from(personnel).sort((a, b) => a.localeCompare(b));
+  const sortedZones = Array.from(zones).sort((a, b) => a.localeCompare(b));
+
+  sortedPersonnel.forEach((name) => {
+    const option = document.createElement('option');
+    option.value = name;
+    option.textContent = name;
+    dispatchDriverFilterEl.appendChild(option);
+  });
+
+  sortedZones.forEach((zone) => {
+    const option = document.createElement('option');
+    option.value = zone;
+    option.textContent = zone;
+    dispatchZoneFilterEl.appendChild(option);
+  });
+}
+
+function normalizeText(value) {
+  return value ? value.toString().trim().toLowerCase() : '';
+}
+
+function getFiltersFromForm() {
+  if (!dispatchFilterForm) return { ...currentDispatchFilters };
+
+  const formData = new FormData(dispatchFilterForm);
+  const customer = normalizeText(formData.get('customer'));
+  const vehicle = normalizeText(formData.get('vehicle'));
+  const driver = normalizeText(formData.get('driver'));
+  const zone = normalizeText(formData.get('zone'));
+
+  const startRaw = formData.get('startDate');
+  const endRaw = formData.get('endDate');
+
+  const startDate = startRaw ? new Date(startRaw) : null;
+  const endDate = endRaw ? new Date(endRaw) : null;
+
+  if (endDate) {
+    endDate.setHours(23, 59, 59, 999);
+  }
+
+  return {
+    customer,
+    vehicle,
+    driver,
+    zone,
+    startDate: startDate && !Number.isNaN(startDate.valueOf()) ? startDate : null,
+    endDate: endDate && !Number.isNaN(endDate.valueOf()) ? endDate : null
+  };
+}
+
+function callMatchesFilters(call, filters) {
+  const customerText = normalizeText(call.customer);
+  const vehicleText = normalizeText(call.vehicle);
+  const driverText = normalizeText(call.driver);
+  const dispatcherText = normalizeText(call.dispatcher);
+  const zoneText = normalizeText(call.zone);
+
+  const matchesCustomer = !filters.customer || customerText.includes(filters.customer);
+  const matchesVehicle = !filters.vehicle || vehicleText.includes(filters.vehicle);
+  const matchesDriver =
+    !filters.driver || driverText === filters.driver || dispatcherText === filters.driver;
+  const matchesZone = !filters.zone || zoneText === filters.zone;
+
+  const openedAt = new Date(call.openedAt);
+  if (filters.startDate && openedAt < filters.startDate) {
+    return false;
+  }
+  if (filters.endDate && openedAt > filters.endDate) {
+    return false;
+  }
+
+  return matchesCustomer && matchesVehicle && matchesDriver && matchesZone;
+}
+
+function formatDateTime(value) {
+  if (!value) return '';
+  const date = new Date(value);
+  if (Number.isNaN(date.valueOf())) return value;
+  const datePart = date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+  const timePart = date.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
+  return `${datePart} · ${timePart}`;
+}
+
+function formatTimeOnly(value) {
+  if (!value) return '';
+  const date = new Date(value);
+  if (Number.isNaN(date.valueOf())) return value;
+  return date.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
+}
+
+function renderCallRows(status, calls) {
+  const body = callTableBodies[status];
+  if (!body) return;
+
+  body.innerHTML = '';
+  const fragment = document.createDocumentFragment();
+
+  if (!calls.length) {
+    const emptyRow = document.createElement('tr');
+    const columnCount = body.closest('table')?.querySelectorAll('thead th').length ?? 1;
+    emptyRow.innerHTML = `<td colspan="${columnCount}" class="empty">No ${status} calls match the filters.</td>`;
+    fragment.appendChild(emptyRow);
+    body.appendChild(fragment);
+    return;
+  }
+
+  calls.forEach((call) => {
+    const row = document.createElement('tr');
+
+    if (status === 'active') {
+      row.innerHTML = `
+        <td>${call.id}</td>
+        <td>
+          <div class="cell-primary">${call.customer}</div>
+          <div class="cell-secondary">${call.location}</div>
+        </td>
+        <td>${call.vehicle}</td>
+        <td>${call.zone}</td>
+        <td>${call.driver}</td>
+        <td>${call.dispatcher}</td>
+        <td>${formatDateTime(call.openedAt)}</td>
+        <td><span class="status-chip status-${call.progress}">${callProgressMeta[call.progress]?.label ?? call.progress}</span></td>
+        <td>${call.eta}</td>
+      `;
+    } else if (status === 'canceled') {
+      row.innerHTML = `
+        <td>${call.id}</td>
+        <td>
+          <div class="cell-primary">${call.customer}</div>
+          <div class="cell-secondary">${call.vehicle}</div>
+        </td>
+        <td>${call.reason ?? call.notes ?? '—'}</td>
+        <td>${call.dispatcher}</td>
+        <td>${formatDateTime(call.updatedAt)}</td>
+      `;
+    } else {
+      row.innerHTML = `
+        <td>${call.id}</td>
+        <td>
+          <div class="cell-primary">${call.customer}</div>
+          <div class="cell-secondary">${call.location}</div>
+        </td>
+        <td>${call.vehicle}</td>
+        <td>${formatDateTime(call.requestedAt ?? call.openedAt)}</td>
+        <td>${formatDateTime(call.scheduledFor ?? call.updatedAt)}</td>
+        <td>${call.zone}</td>
+        <td>${call.notes}</td>
+      `;
+    }
+
+    fragment.appendChild(row);
+  });
+
+  body.appendChild(fragment);
+}
+
+function updateCallCounts(groupedCalls) {
+  callCountBadges.forEach((badge) => {
+    const key = badge.dataset.callCount;
+    badge.textContent = groupedCalls[key]?.length ?? 0;
+  });
+
+  if (liveCallCountEl) {
+    liveCallCountEl.textContent = groupedCalls.active?.length ?? 0;
+  }
+}
+
+function renderCallSummary(calls) {
+  if (!callSummaryEl) return;
+
+  callSummaryEl.innerHTML = '';
+  const fragment = document.createDocumentFragment();
+  const counts = {};
+
+  calls.forEach((call) => {
+    const key = call.progress in callProgressMeta ? call.progress : 'waiting';
+    counts[key] = (counts[key] ?? 0) + 1;
+  });
+
+  Object.entries(callProgressMeta).forEach(([key, meta]) => {
+    const count = counts[key] ?? 0;
+    const chip = document.createElement('div');
+    chip.className = `summary-chip ${meta.accent}${count === 0 ? ' muted' : ''}`;
+    chip.innerHTML = `
+      <span class="chip-count">${count}</span>
+      <div class="chip-labels">
+        <span class="chip-title">${meta.label}</span>
+        <span class="chip-subtitle">${meta.description}</span>
+      </div>
+    `;
+    fragment.appendChild(chip);
+  });
+
+  callSummaryEl.appendChild(fragment);
+}
+
+function renderDispatchTables() {
+  const filteredCalls = dispatchCalls.filter((call) => callMatchesFilters(call, currentDispatchFilters));
+
+  const grouped = {
+    active: [],
+    canceled: [],
+    queued: []
+  };
+
+  filteredCalls.forEach((call) => {
+    const key = grouped[call.status] ? call.status : 'active';
+    grouped[key].push(call);
+  });
+
+  Object.entries(grouped).forEach(([status, calls]) => {
+    renderCallRows(status, calls);
+  });
+
+  updateCallCounts(grouped);
+  renderCallSummary(filteredCalls);
+}
+
+function setActiveDispatchTab(tabId) {
+  activeDispatchTab = tabId;
+
+  dispatchTabs.forEach((tab) => {
+    const isActive = tab.dataset.dispatchTab === tabId;
+    tab.classList.toggle('active', isActive);
+    tab.setAttribute('aria-selected', isActive ? 'true' : 'false');
+  });
+
+  dispatchPanels.forEach((panel) => {
+    const isActive = panel.dataset.dispatchPanel === tabId;
+    panel.hidden = !isActive;
+  });
+}
+
+function getUnreadCount(messages) {
+  return messages.filter((message) => message.from === 'driver' && !message.read).length;
+}
+
+function renderDriverRoster() {
+  if (!messagingRosterEl) return;
+
+  messagingRosterEl.innerHTML = '';
+  const fragment = document.createDocumentFragment();
+
+  driverProfiles.forEach((driver) => {
+    const unreadCount = getUnreadCount(driver.messages);
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'roster-item';
+    button.dataset.driverId = driver.id;
+    button.innerHTML = `
+      <div class="roster-top">
+        <span class="roster-name">${driver.name}</span>
+        <span class="roster-status">${driver.status}</span>
+      </div>
+      <div class="roster-bottom">
+        <span class="roster-unit">${driver.unit}</span>
+        <span class="roster-meta">Last update · ${driver.lastActive}</span>
+      </div>
+      ${unreadCount ? `<span class="roster-unread" aria-label="${unreadCount} unread messages">${unreadCount}</span>` : ''}
+    `;
+
+    if (driver.id === activeDriverId) {
+      button.classList.add('active');
+    }
+
+    button.addEventListener('click', () => {
+      setActiveDriver(driver.id);
+    });
+
+    fragment.appendChild(button);
+  });
+
+  messagingRosterEl.appendChild(fragment);
+}
+
+function scrollLogToBottom() {
+  if (messageLogEl) {
+    messageLogEl.scrollTop = messageLogEl.scrollHeight;
+  }
+}
+
+function markDriverMessagesRead(driver) {
+  let updated = false;
+  driver.messages.forEach((message) => {
+    if (message.from === 'driver' && !message.read) {
+      message.read = true;
+      updated = true;
+    }
+  });
+  return updated;
+}
+
+function renderMessageLog(driver) {
+  if (!messageLogEl) return;
+
+  messageLogEl.innerHTML = '';
+
+  if (!driver) {
+    const emptyState = document.createElement('div');
+    emptyState.className = 'message-empty';
+    emptyState.textContent = 'Select a driver to view the conversation.';
+    messageLogEl.appendChild(emptyState);
+    return;
+  }
+
+  const fragment = document.createDocumentFragment();
+
+  driver.messages.forEach((message) => {
+    const bubble = document.createElement('div');
+    bubble.className = `message-bubble ${message.from}`;
+    bubble.innerHTML = `
+      <div class="message-body">${message.body}</div>
+      <div class="message-meta">${message.timestamp}${message.from === 'driver' && !message.read ? ' · unread' : ''}</div>
+    `;
+    fragment.appendChild(bubble);
+  });
+
+  messageLogEl.appendChild(fragment);
+  scrollLogToBottom();
+}
+
+function updateMessagingFormState() {
+  const hasDriver = Boolean(activeDriverId);
+  if (messageInputEl) messageInputEl.disabled = !hasDriver;
+  if (messageSubmitButton) messageSubmitButton.disabled = !hasDriver;
+  if (markThreadReadButton) markThreadReadButton.disabled = !hasDriver;
+}
+
+function setActiveDriver(driverId) {
+  activeDriverId = driverId;
+  const driver = driverProfiles.find((item) => item.id === driverId) ?? null;
+
+  if (activeThreadNameEl) {
+    activeThreadNameEl.textContent = driver ? driver.name : 'Select a driver';
+  }
+  if (activeThreadStatusEl) {
+    activeThreadStatusEl.textContent = driver ? `${driver.status} · ${driver.unit}` : '';
+  }
+
+  if (driver) {
+    markDriverMessagesRead(driver);
+  }
+
+  renderDriverRoster();
+
+  renderMessageLog(driver);
+  updateMessagingFormState();
+}
+
+function getSurveyStatusLabel(status) {
+  switch (status) {
+    case 'active':
+      return 'Active';
+    case 'scheduled':
+      return 'Scheduled';
+    case 'paused':
+      return 'Paused';
+    default:
+      return status;
+  }
+}
+
+function formatPercent(value) {
+  return `${Math.round(value * 100)}%`;
+}
+
+function renderSurveyList() {
+  if (!surveyListEl) return;
+
+  surveyListEl.innerHTML = '';
+  const fragment = document.createDocumentFragment();
+
+  const filtered = surveyTemplates.filter((survey) => {
+    const matchesCategory = surveyFilters.category === 'all' || survey.category === surveyFilters.category;
+    const matchesStatus = surveyFilters.status === 'all' || survey.status === surveyFilters.status;
+    const searchText = normalizeText(survey.title);
+    const matchesSearch = !surveyFilters.search || searchText.includes(surveyFilters.search);
+    return matchesCategory && matchesStatus && matchesSearch;
+  });
+
+  if (!filtered.length) {
+    const empty = document.createElement('div');
+    empty.className = 'survey-empty';
+    empty.textContent = 'No surveys match the applied filters.';
+    surveyListEl.appendChild(empty);
+    return;
+  }
+
+  filtered.forEach((survey) => {
+    const card = document.createElement('article');
+    card.className = `survey-card status-${survey.status}`;
+    card.setAttribute('role', 'listitem');
+    card.innerHTML = `
+      <header class="survey-header">
+        <h3>${survey.title}</h3>
+        <span class="survey-status">${getSurveyStatusLabel(survey.status)}</span>
+      </header>
+      <div class="survey-meta">
+        <span class="survey-meta-item"><strong>Category:</strong> ${survey.category}</span>
+        <span class="survey-meta-item"><strong>Last Sent:</strong> ${survey.lastSent}</span>
+      </div>
+      <div class="survey-stats">
+        <span><strong>Responses:</strong> ${survey.responses}</span>
+        <span><strong>Completion:</strong> ${formatPercent(survey.completionRate)}</span>
+      </div>
+      <div class="survey-actions">
+        <button type="button" class="secondary-action" data-survey-action="toggle" data-survey-id="${survey.id}">${getSurveyActionLabel(survey.status)}</button>
+        <button type="button" class="link-action" data-survey-action="preview" data-survey-id="${survey.id}">Preview</button>
+      </div>
+    `;
+    fragment.appendChild(card);
+  });
+
+  surveyListEl.appendChild(fragment);
+}
+
+function getSurveyActionLabel(status) {
+  switch (status) {
+    case 'active':
+      return 'Pause Sending';
+    case 'paused':
+      return 'Resume Survey';
+    case 'scheduled':
+      return 'Activate Now';
+    default:
+      return 'Update';
+  }
+}
+
+function toggleSurveyStatus(surveyId) {
+  const survey = surveyTemplates.find((item) => item.id === surveyId);
+  if (!survey) return;
+
+  if (survey.status === 'active') {
+    survey.status = 'paused';
+  } else {
+    survey.status = 'active';
+    const today = new Date();
+    survey.lastSent = today.toISOString().slice(0, 10);
+  }
+
+  renderSurveyList();
+}
+
+function handleSurveyClick(event) {
+  const target = event.target;
+  if (!(target instanceof HTMLElement)) return;
+
+  const surveyId = target.dataset.surveyId;
+  const action = target.dataset.surveyAction;
+  if (!surveyId || !action) return;
+
+  if (action === 'toggle') {
+    toggleSurveyStatus(surveyId);
+  } else if (action === 'preview') {
+    target.blur();
+    target.setAttribute('data-previewed', 'true');
+  }
+}
+
+function renderDashboard() {
+  renderDashboardMetrics();
+  renderDashboardDispatchRows();
+  renderImpounds();
+  renderReports();
+}
+
+function renderDispatchingModule() {
+  populateDispatchFilters();
+  renderDispatchTables();
+  renderDriverRoster();
+  renderMessageLog(null);
+  updateMessagingFormState();
+  renderSurveyList();
+}
+
+function initNavigation() {
+  navLinks.forEach((link) => {
+    link.addEventListener('click', (event) => {
+      event.preventDefault();
+      const target = link.dataset.viewTarget;
+      if (target === 'dashboard' || target === 'dispatching') {
+        setActiveView(target);
+      }
+    });
+  });
+
+  if (goToDispatchButton) {
+    goToDispatchButton.addEventListener('click', () => {
+      setActiveView('dispatching');
+    });
+  }
+}
+
+function initDashboardEvents() {
+  if (statusFilterEl) {
+    statusFilterEl.addEventListener('change', (event) => {
+      renderDashboardDispatchRows(event.target.value);
+    });
+  }
+
+  if (refreshBoardButton) {
+    refreshBoardButton.addEventListener('click', (event) => {
+      const button = event.currentTarget;
+      button.disabled = true;
+      button.textContent = 'Refreshing…';
+      setTimeout(() => {
+        renderDashboardDispatchRows(statusFilterEl?.value ?? 'all');
+        button.disabled = false;
+        button.textContent = 'Refresh';
+      }, 600);
+    });
+  }
+}
+
+function initDispatchEvents() {
+  dispatchTabs.forEach((tab) => {
+    tab.addEventListener('click', () => {
+      const tabId = tab.dataset.dispatchTab;
+      if (tabId) {
+        setActiveDispatchTab(tabId);
+      }
+    });
+  });
+
+  if (dispatchFilterForm) {
+    dispatchFilterForm.addEventListener('submit', (event) => {
+      event.preventDefault();
+      currentDispatchFilters = getFiltersFromForm();
+      renderDispatchTables();
+    });
+
+    dispatchFilterForm.addEventListener('reset', () => {
+      setTimeout(() => {
+        currentDispatchFilters = {
+          customer: '',
+          vehicle: '',
+          driver: '',
+          zone: '',
+          startDate: null,
+          endDate: null
+        };
+        renderDispatchTables();
+      }, 0);
+    });
+  }
+
+  if (messageFormEl) {
+    messageFormEl.addEventListener('submit', (event) => {
+      event.preventDefault();
+      if (!activeDriverId || !messageInputEl) return;
+      const messageText = messageInputEl.value.trim();
+      if (!messageText) return;
+
+      const driver = driverProfiles.find((item) => item.id === activeDriverId);
+      if (!driver) return;
+
+      const timestamp = new Date().toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
+      driver.messages.push({
+        id: generateMessageId(),
+        from: 'dispatcher',
+        body: messageText,
+        timestamp,
+        read: true
+      });
+      driver.lastActive = timestamp;
+
+      messageInputEl.value = '';
+      renderMessageLog(driver);
+      renderDriverRoster();
+    });
+  }
+
+  if (markThreadReadButton) {
+    markThreadReadButton.addEventListener('click', () => {
+      if (!activeDriverId) return;
+      const driver = driverProfiles.find((item) => item.id === activeDriverId);
+      if (!driver) return;
+      if (markDriverMessagesRead(driver)) {
+        renderDriverRoster();
+        renderMessageLog(driver);
+      }
+    });
+  }
+
+  if (surveyFilterForm) {
+    surveyFilterForm.addEventListener('submit', (event) => {
+      event.preventDefault();
+      const formData = new FormData(surveyFilterForm);
+      surveyFilters = {
+        category: formData.get('category') ?? 'all',
+        status: formData.get('status') ?? 'all',
+        search: normalizeText(formData.get('search'))
+      };
+      renderSurveyList();
+    });
+
+    surveyFilterForm.addEventListener('reset', () => {
+      setTimeout(() => {
+        surveyFilters = {
+          category: 'all',
+          status: 'all',
+          search: ''
+        };
+        renderSurveyList();
+      }, 0);
+    });
+  }
+
+  if (surveyListEl) {
+    surveyListEl.addEventListener('click', handleSurveyClick);
+  }
+}
+
+function init() {
+  setActiveView('dashboard');
+  setActiveDispatchTab(activeDispatchTab);
+  renderDashboard();
+  renderDispatchingModule();
+  initNavigation();
+  initDashboardEvents();
+  initDispatchEvents();
+}
+
+document.addEventListener('DOMContentLoaded', init);

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,1052 @@
+:root {
+  --blue-500: #1d6cc6;
+  --blue-600: #14539b;
+  --blue-050: #f1f6fb;
+  --gray-025: #f8f9fb;
+  --gray-050: #eef1f5;
+  --gray-100: #dfe4ea;
+  --gray-400: #7b8794;
+  --gray-500: #4d5766;
+  --gray-900: #1e2530;
+  --green-500: #2f9d4d;
+  --red-500: #cf3030;
+  --orange-500: #ff8a4c;
+  --font-base: "Roboto", sans-serif;
+  --shadow-sm: 0 2px 6px rgba(16, 24, 40, 0.08);
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: var(--font-base);
+  background: var(--gray-025);
+  color: var(--gray-500);
+  min-height: 100vh;
+}
+
+.app-shell {
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  min-height: 100vh;
+}
+
+.topbar {
+  background: var(--blue-500);
+  color: #fff;
+  display: flex;
+  align-items: center;
+  padding: 0 2.5rem;
+  height: 72px;
+  gap: 2rem;
+  box-shadow: var(--shadow-sm);
+}
+
+.brand {
+  font-weight: 700;
+  font-size: 1.4rem;
+  letter-spacing: 0.02em;
+  text-transform: lowercase;
+}
+
+.brand-cloud {
+  font-weight: 400;
+  font-size: 0.85rem;
+  display: inline-block;
+  margin-left: 0.3rem;
+  padding: 0.15rem 0.5rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.25);
+}
+
+.primary-nav {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+.nav-link {
+  color: rgba(255, 255, 255, 0.85);
+  text-decoration: none;
+  font-weight: 500;
+  font-size: 0.95rem;
+  position: relative;
+  padding-bottom: 0.2rem;
+}
+
+.nav-link.active::after,
+.nav-link:hover::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: -0.4rem;
+  width: 100%;
+  height: 3px;
+  background: #fff;
+  border-radius: 999px;
+}
+
+.user-meta {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+  font-size: 0.85rem;
+}
+
+.support strong {
+  font-weight: 700;
+}
+
+.user-info {
+  text-align: right;
+}
+
+.user-name {
+  font-weight: 600;
+}
+
+.user-status {
+  background: rgba(255, 255, 255, 0.2);
+  padding: 0.25rem 0.8rem;
+  border-radius: 999px;
+  font-weight: 500;
+  font-size: 0.8rem;
+}
+
+.dashboard-view {
+  padding: 2.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.welcome-card {
+  background: #fff;
+  padding: 1.75rem 2rem;
+  border-radius: 16px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  box-shadow: var(--shadow-sm);
+}
+
+.welcome-card h1 {
+  color: var(--gray-900);
+  font-size: 1.6rem;
+  margin-bottom: 0.5rem;
+}
+
+.welcome-card span {
+  color: var(--blue-500);
+}
+
+.primary-action {
+  background: var(--blue-500);
+  color: #fff;
+  border: none;
+  border-radius: 10px;
+  padding: 0.75rem 1.5rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.primary-action:hover {
+  background: var(--blue-600);
+}
+
+.dispatch-overview {
+  background: #fff;
+  border-radius: 16px;
+  padding: 1.5rem 2rem;
+  box-shadow: var(--shadow-sm);
+}
+
+.section-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1.5rem;
+}
+
+.section-heading h2 {
+  color: var(--gray-900);
+  font-size: 1.1rem;
+}
+
+.section-heading .meta {
+  font-size: 0.85rem;
+  color: var(--gray-400);
+}
+
+.metric-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1rem;
+}
+
+.metric-card {
+  border: 1px solid var(--gray-100);
+  border-radius: 14px;
+  padding: 1rem 1.25rem;
+  background: var(--gray-050);
+  display: grid;
+  gap: 0.3rem;
+}
+
+.metric-title {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  font-weight: 600;
+  color: var(--gray-400);
+}
+
+.metric-value {
+  font-size: 1.8rem;
+  font-weight: 700;
+  color: var(--gray-900);
+}
+
+.metric-subtext {
+  font-size: 0.75rem;
+  color: var(--gray-400);
+}
+
+.live-board {
+  background: #fff;
+  border-radius: 16px;
+  box-shadow: var(--shadow-sm);
+  padding: 1.5rem 2rem;
+  display: grid;
+  gap: 1.5rem;
+}
+
+.controls {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.filter {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+}
+
+.filter select {
+  padding: 0.4rem 0.75rem;
+  border-radius: 8px;
+  border: 1px solid var(--gray-100);
+  background: #fff;
+}
+
+.secondary-action {
+  border: 1px solid var(--gray-100);
+  background: transparent;
+  padding: 0.5rem 1rem;
+  border-radius: 8px;
+  cursor: pointer;
+  font-weight: 500;
+  transition: border 0.2s ease, color 0.2s ease;
+}
+
+.secondary-action:hover {
+  border-color: var(--blue-500);
+  color: var(--blue-500);
+}
+
+.board-content {
+  border: 1px solid var(--gray-100);
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+.data-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+}
+
+.data-table th,
+.data-table td {
+  text-align: left;
+  padding: 0.85rem 1rem;
+}
+
+.data-table thead {
+  background: var(--gray-050);
+  color: var(--gray-400);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-size: 0.75rem;
+}
+
+.data-table tbody tr:nth-child(odd) {
+  background: #fff;
+}
+
+.data-table tbody tr:nth-child(even) {
+  background: var(--gray-025);
+}
+
+.data-table td.empty {
+  text-align: center;
+  font-style: italic;
+  color: var(--gray-400);
+}
+
+.status-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.2rem 0.65rem;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.status-waiting {
+  background: rgba(255, 138, 76, 0.12);
+  color: var(--orange-500);
+}
+
+.status-dispatched,
+.status-enroute {
+  background: rgba(29, 108, 198, 0.12);
+  color: var(--blue-500);
+}
+
+.status-onscene {
+  background: rgba(47, 157, 77, 0.12);
+  color: var(--green-500);
+}
+
+.status-towing {
+  background: rgba(47, 157, 77, 0.12);
+  color: var(--green-500);
+}
+
+.status-completed {
+  background: rgba(47, 157, 77, 0.18);
+  color: var(--green-500);
+}
+
+.status-canceled {
+  background: rgba(207, 48, 48, 0.12);
+  color: var(--red-500);
+}
+
+.grid-panels {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1.5rem;
+}
+
+.panel {
+  background: #fff;
+  border-radius: 16px;
+  box-shadow: var(--shadow-sm);
+  padding: 1.5rem;
+  display: grid;
+  gap: 1.2rem;
+}
+
+.panel .link {
+  font-size: 0.85rem;
+  color: var(--blue-500);
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.impound-list {
+  list-style: none;
+  display: grid;
+  gap: 1rem;
+}
+
+.impound-item {
+  border: 1px solid var(--gray-100);
+  border-radius: 12px;
+  padding: 1rem;
+  display: grid;
+  gap: 0.35rem;
+  background: var(--gray-050);
+}
+
+.impound-item h3 {
+  font-size: 1rem;
+  color: var(--gray-900);
+}
+
+.impound-item span {
+  font-size: 0.8rem;
+  color: var(--gray-400);
+}
+
+.view[hidden] {
+  display: none !important;
+}
+
+.dispatch-view {
+  padding: 2.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.dispatch-hero {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: #fff;
+  border-radius: 16px;
+  padding: 1.75rem 2rem;
+  box-shadow: var(--shadow-sm);
+  gap: 2rem;
+}
+
+.dispatch-hero h1 {
+  color: var(--gray-900);
+  font-size: 1.6rem;
+  margin-bottom: 0.35rem;
+}
+
+.dispatch-meta {
+  display: flex;
+  gap: 1.5rem;
+  align-items: center;
+}
+
+.meta-block {
+  display: grid;
+  gap: 0.25rem;
+  text-align: right;
+}
+
+.meta-label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--gray-400);
+}
+
+.meta-value {
+  font-size: 1.2rem;
+  font-weight: 700;
+  color: var(--blue-500);
+}
+
+.dispatch-tabs {
+  display: inline-flex;
+  background: #fff;
+  border-radius: 12px;
+  padding: 0.4rem;
+  box-shadow: var(--shadow-sm);
+  gap: 0.4rem;
+}
+
+.dispatch-tab {
+  border: none;
+  background: transparent;
+  padding: 0.6rem 1.4rem;
+  border-radius: 10px;
+  font-weight: 600;
+  color: var(--gray-400);
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.dispatch-tab.active {
+  background: var(--blue-500);
+  color: #fff;
+  box-shadow: var(--shadow-sm);
+}
+
+.dispatch-panel {
+  background: #fff;
+  border-radius: 16px;
+  padding: 1.75rem 2rem;
+  box-shadow: var(--shadow-sm);
+  display: grid;
+  gap: 1.75rem;
+}
+
+.dispatch-filters {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem 1.5rem;
+  align-items: end;
+}
+
+.form-field {
+  display: grid;
+  gap: 0.4rem;
+  font-size: 0.85rem;
+  color: var(--gray-400);
+}
+
+.form-field input,
+.form-field select,
+.form-field textarea {
+  border: 1px solid var(--gray-100);
+  border-radius: 10px;
+  padding: 0.6rem 0.8rem;
+  font-size: 0.95rem;
+  color: var(--gray-500);
+  background: #fff;
+}
+
+.form-field input:focus,
+.form-field select:focus,
+.form-field textarea:focus {
+  outline: 2px solid rgba(29, 108, 198, 0.25);
+  border-color: var(--blue-500);
+}
+
+.date-range .date-inputs {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.form-actions {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.call-summary {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 0.75rem;
+}
+
+.summary-chip {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.85rem 1rem;
+  border-radius: 12px;
+  background: var(--gray-050);
+  border: 1px solid var(--gray-100);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.summary-chip:not(.muted):hover {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-sm);
+}
+
+.summary-chip .chip-count {
+  font-size: 2rem;
+  font-weight: 700;
+  color: var(--gray-900);
+}
+
+.summary-chip.muted .chip-count {
+  color: var(--gray-100);
+}
+
+.chip-labels {
+  display: grid;
+  gap: 0.15rem;
+}
+
+.chip-title {
+  font-weight: 600;
+  color: var(--gray-500);
+}
+
+.chip-subtitle {
+  font-size: 0.75rem;
+  color: var(--gray-400);
+}
+
+.accent-new {
+  border-color: rgba(29, 108, 198, 0.25);
+}
+
+.accent-waiting {
+  border-color: rgba(255, 138, 76, 0.25);
+}
+
+.accent-destination,
+.accent-completed {
+  border-color: rgba(47, 157, 77, 0.25);
+}
+
+.accent-canceled {
+  border-color: rgba(207, 48, 48, 0.25);
+}
+
+.accent-queued {
+  border-color: rgba(29, 108, 198, 0.15);
+}
+
+.call-sections {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 1.5rem;
+}
+
+.call-panel {
+  border: 1px solid var(--gray-100);
+  border-radius: 14px;
+  overflow: hidden;
+  background: #fff;
+  display: grid;
+  gap: 0;
+}
+
+.panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: var(--gray-050);
+  padding: 1rem 1.25rem;
+  border-bottom: 1px solid var(--gray-100);
+}
+
+.panel-header h2 {
+  font-size: 1rem;
+  color: var(--gray-900);
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 28px;
+  border-radius: 8px;
+  background: var(--blue-050);
+  color: var(--blue-500);
+  font-weight: 600;
+}
+
+.cell-primary {
+  font-weight: 600;
+  color: var(--gray-900);
+}
+
+.cell-secondary {
+  font-size: 0.75rem;
+  color: var(--gray-400);
+}
+
+.status-new {
+  background: rgba(29, 108, 198, 0.12);
+  color: var(--blue-500);
+}
+
+.status-destination {
+  background: rgba(47, 157, 77, 0.12);
+  color: var(--green-500);
+}
+
+.status-queued {
+  background: rgba(255, 138, 76, 0.12);
+  color: var(--orange-500);
+}
+
+.messaging-layout {
+  display: grid;
+  grid-template-columns: minmax(220px, 260px) 1fr;
+  gap: 1.5rem;
+}
+
+.messaging-roster {
+  border: 1px solid var(--gray-100);
+  border-radius: 14px;
+  overflow: hidden;
+  display: grid;
+  background: var(--gray-050);
+}
+
+.roster-item {
+  text-align: left;
+  border: none;
+  background: transparent;
+  padding: 1rem 1.25rem;
+  border-bottom: 1px solid var(--gray-100);
+  display: grid;
+  gap: 0.4rem;
+  cursor: pointer;
+  position: relative;
+  transition: background 0.2s ease;
+}
+
+.roster-item:last-child {
+  border-bottom: none;
+}
+
+.roster-item.active,
+.roster-item:hover {
+  background: #fff;
+}
+
+.roster-top {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.9rem;
+  color: var(--gray-900);
+  font-weight: 600;
+}
+
+.roster-status {
+  font-size: 0.75rem;
+  color: var(--gray-400);
+}
+
+.roster-bottom {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.75rem;
+  color: var(--gray-400);
+}
+
+.roster-unread {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  background: var(--red-500);
+  color: #fff;
+  width: 22px;
+  height: 22px;
+  border-radius: 999px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.7rem;
+  font-weight: 700;
+}
+
+.messaging-thread {
+  border: 1px solid var(--gray-100);
+  border-radius: 14px;
+  padding: 1.5rem;
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  gap: 1rem;
+  background: var(--gray-050);
+}
+
+.thread-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+}
+
+.thread-title {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--gray-900);
+}
+
+.thread-status {
+  font-size: 0.8rem;
+  color: var(--gray-400);
+}
+
+.message-log {
+  border: 1px solid var(--gray-100);
+  border-radius: 12px;
+  padding: 1rem;
+  background: #fff;
+  overflow-y: auto;
+  max-height: 320px;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.message-bubble {
+  display: grid;
+  gap: 0.35rem;
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  max-width: 80%;
+}
+
+.message-bubble.driver {
+  background: rgba(29, 108, 198, 0.1);
+  color: var(--blue-600);
+  justify-self: flex-start;
+}
+
+.message-bubble.dispatcher {
+  background: rgba(47, 157, 77, 0.15);
+  color: var(--gray-900);
+  justify-self: flex-end;
+}
+
+.message-body {
+  font-size: 0.9rem;
+}
+
+.message-meta {
+  font-size: 0.7rem;
+  color: var(--gray-400);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.message-empty {
+  color: var(--gray-400);
+  font-style: italic;
+  text-align: center;
+  padding: 2rem 1rem;
+}
+
+.message-form {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.message-form textarea {
+  resize: none;
+  min-height: 70px;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.survey-filters {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem 1.5rem;
+  align-items: end;
+}
+
+.survey-list {
+  display: grid;
+  gap: 1rem;
+}
+
+.survey-card {
+  border: 1px solid var(--gray-100);
+  border-radius: 14px;
+  padding: 1.25rem;
+  background: var(--gray-050);
+  display: grid;
+  gap: 0.75rem;
+}
+
+.survey-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+}
+
+.survey-header h3 {
+  font-size: 1rem;
+  color: var(--gray-900);
+}
+
+.survey-status {
+  font-size: 0.75rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(29, 108, 198, 0.12);
+  color: var(--blue-500);
+  font-weight: 600;
+}
+
+.survey-card.status-paused .survey-status {
+  background: rgba(207, 48, 48, 0.12);
+  color: var(--red-500);
+}
+
+.survey-card.status-scheduled .survey-status {
+  background: rgba(255, 138, 76, 0.12);
+  color: var(--orange-500);
+}
+
+.survey-meta,
+.survey-stats {
+  display: flex;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+  font-size: 0.85rem;
+  color: var(--gray-400);
+}
+
+.survey-actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.link-action {
+  border: none;
+  background: none;
+  color: var(--blue-500);
+  font-weight: 600;
+  cursor: pointer;
+  padding: 0;
+}
+
+.survey-empty {
+  text-align: center;
+  color: var(--gray-400);
+  font-style: italic;
+  padding: 2rem 1rem;
+  border: 1px dashed var(--gray-100);
+  border-radius: 12px;
+}
+
+button:disabled,
+.secondary-action:disabled,
+.primary-action:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.reports {
+  display: grid;
+  gap: 1rem;
+}
+
+.report-card {
+  border: 1px solid var(--gray-100);
+  border-radius: 12px;
+  padding: 1.2rem;
+  background: var(--gray-050);
+  display: grid;
+  gap: 0.5rem;
+}
+
+.report-card h3 {
+  font-size: 0.95rem;
+  color: var(--gray-900);
+}
+
+.highlight {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: var(--gray-900);
+}
+
+.trend {
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.trend.positive {
+  color: var(--green-500);
+}
+
+.trend.negative {
+  color: var(--red-500);
+}
+
+.trend.stable {
+  color: var(--gray-400);
+}
+
+.footer {
+  background: #fff;
+  padding: 1.25rem 2.5rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border-top: 1px solid var(--gray-100);
+  font-size: 0.85rem;
+}
+
+.footer-links {
+  display: flex;
+  gap: 1rem;
+}
+
+.footer-links a {
+  color: var(--gray-400);
+  text-decoration: none;
+}
+
+@media (max-width: 1024px) {
+  .topbar {
+    padding: 0 1.5rem;
+    gap: 1rem;
+  }
+
+  .primary-nav {
+    display: none;
+  }
+
+  .dashboard-view {
+    padding: 1.5rem;
+  }
+
+  .dispatch-view {
+    padding: 1.5rem;
+  }
+
+  .dispatch-hero {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .dispatch-meta {
+    width: 100%;
+    justify-content: space-between;
+  }
+}
+
+@media (max-width: 768px) {
+  .welcome-card {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .user-meta {
+    display: none;
+  }
+
+  .controls {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .board-content {
+    overflow-x: auto;
+  }
+
+  .dispatch-tabs {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .dispatch-tabs .dispatch-tab {
+    flex: 1;
+    text-align: center;
+  }
+
+  .call-sections {
+    grid-template-columns: 1fr;
+  }
+
+  .messaging-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .dispatch-meta {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.75rem;
+  }
+}


### PR DESCRIPTION
## Summary
- add single-page navigation that exposes a dedicated dispatching workspace alongside the dashboard
- implement interactive dispatch tabs for live calls, driver messaging, and survey management with dynamic filtering
- refresh styling and documentation to cover the new dispatch workflow

## Testing
- Manual: python -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68da8ca0dc688329bc2e5996dbdd113a