### PR TITLE
Add interactive impound lot management view

### DIFF
--- a/index.html
+++ b/index.html
@@ -336,6 +336,125 @@
         </section>
       </main>
 
+      <main class="view impound-view" data-view="impounds" hidden>
+        <header class="impound-header">
+          <div class="impound-heading">
+            <h1>Impound Lot</h1>
+            <p>Track vehicles on hold, view balances, and manage release requests.</p>
+          </div>
+          <div class="impound-actions">
+            <button type="button" class="primary-action">New Impound</button>
+            <button type="button" class="secondary-action impound-report-action">
+              Create Report
+              <span aria-hidden="true" class="chevron">▾</span>
+            </button>
+          </div>
+        </header>
+
+        <div class="impound-toolbar">
+          <nav class="impound-tabs" role="tablist" aria-label="Impound filters">
+            <button
+              type="button"
+              class="impound-tab active"
+              role="tab"
+              aria-selected="true"
+              data-impound-tab="current"
+            >
+              Current
+            </button>
+            <button
+              type="button"
+              class="impound-tab"
+              role="tab"
+              aria-selected="false"
+              data-impound-tab="stock-in"
+            >
+              Stock In
+            </button>
+            <button
+              type="button"
+              class="impound-tab"
+              role="tab"
+              aria-selected="false"
+              data-impound-tab="stock-out"
+            >
+              Stock Out
+            </button>
+            <button
+              type="button"
+              class="impound-tab"
+              role="tab"
+              aria-selected="false"
+              data-impound-tab="account"
+            >
+              Account
+            </button>
+          </nav>
+
+          <form class="impound-search" id="impound-search-form" role="search">
+            <label class="sr-only" for="impound-search-input">Search impounds</label>
+            <input
+              type="search"
+              id="impound-search-input"
+              name="query"
+              placeholder="Search"
+              autocomplete="off"
+            />
+            <div class="impound-search-actions">
+              <button type="submit" class="secondary-action">Search</button>
+              <button type="reset" class="link-action">Reset</button>
+            </div>
+          </form>
+        </div>
+
+        <section class="impound-lot" aria-labelledby="impound-table-heading">
+          <div class="impound-table-wrapper">
+            <h2 id="impound-table-heading" class="sr-only">Impound inventory</h2>
+            <table class="data-table impound-table">
+              <thead>
+                <tr>
+                  <th scope="col">Stock #</th>
+                  <th scope="col">Call #</th>
+                  <th scope="col">In / Out</th>
+                  <th scope="col">Account</th>
+                  <th scope="col">Vehicle</th>
+                  <th scope="col">Plate</th>
+                  <th scope="col">VIN</th>
+                  <th scope="col">Impound Date</th>
+                  <th scope="col">Days Held</th>
+                  <th scope="col">Total</th>
+                  <th scope="col">Balance Due</th>
+                  <th scope="col">Storage Lot</th>
+                </tr>
+                <tr class="impound-filter-row">
+                  <th><input type="text" placeholder="Filter" data-impound-filter="stock" /></th>
+                  <th><input type="text" placeholder="Filter" data-impound-filter="call" /></th>
+                  <th>
+                    <select data-impound-filter="direction">
+                      <option value="all">All</option>
+                      <option value="in">In</option>
+                      <option value="out">Out</option>
+                    </select>
+                  </th>
+                  <th><input type="text" placeholder="Filter" data-impound-filter="account" /></th>
+                  <th><input type="text" placeholder="Filter" data-impound-filter="vehicle" /></th>
+                  <th><input type="text" placeholder="Filter" data-impound-filter="plate" /></th>
+                  <th><input type="text" placeholder="Filter" data-impound-filter="vin" /></th>
+                  <th><input type="date" data-impound-filter="impoundDate" /></th>
+                  <th><input type="number" min="0" placeholder="" data-impound-filter="daysHeld" /></th>
+                  <th><input type="number" min="0" step="0.01" placeholder="" data-impound-filter="total" /></th>
+                  <th><input type="number" min="0" step="0.01" placeholder="" data-impound-filter="balanceDue" /></th>
+                  <th><input type="text" placeholder="Filter" data-impound-filter="storageLot" /></th>
+                </tr>
+              </thead>
+              <tbody id="impound-table-body"></tbody>
+            </table>
+          </div>
+
+          <aside class="impound-detail" id="impound-detail"></aside>
+        </section>
+      </main>
+
       <footer class="footer">
         <div>© 2024 Towbook Cloud. All rights reserved.</div>
         <div class="footer-links">

--- a/script.js
+++ b/script.js
@@ -5,6 +5,13 @@ const statusFilterEl = document.querySelector('#status-filter');
 const refreshBoardButton = document.querySelector('#refresh-board');
 const goToDispatchButton = document.querySelector('#go-to-dispatch');
 
+const impoundTableBodyEl = document.querySelector('#impound-table-body');
+const impoundDetailEl = document.querySelector('#impound-detail');
+const impoundFilterInputs = document.querySelectorAll('[data-impound-filter]');
+const impoundSearchFormEl = document.querySelector('#impound-search-form');
+const impoundSearchInputEl = document.querySelector('#impound-search-input');
+const impoundTabButtons = document.querySelectorAll('[data-impound-tab]');
+
 const navLinks = document.querySelectorAll('.nav-link[data-view-target]');
 const views = document.querySelectorAll('.view[data-view]');
 
@@ -141,6 +148,121 @@ const impoundVehicles = [
     releaseDate: 'Due 09/30'
   }
 ];
+
+const impoundLotRecords = [
+  {
+    id: 'STK-2215',
+    call: 'TB-2078',
+    direction: 'in',
+    account: 'City of Detroit PD',
+    vehicle: '2018 Ford Explorer · Unit 42',
+    plate: 'PDX 4287',
+    vin: '1FM5K8AR7JGA42158',
+    impoundDate: '2024-09-18',
+    daysHeld: 12,
+    total: 425.5,
+    balanceDue: 214.5,
+    storageLot: 'Main Lot · Row 3 · Space 18',
+    status: 'current',
+    holdReason: 'Police hold pending supervisor review before release.',
+    contact: 'Officer Ramirez · (313) 555-0148',
+    releaseSteps: 'Supervisor approval and proof of insurance required.',
+    paymentStatus: 'Balance due at release',
+    vehicleColor: 'Oxford White',
+    vehicleNotes: 'Keys secured in locker 12. Dash cam removed and logged.'
+  },
+  {
+    id: 'STK-2220',
+    call: 'TB-2091',
+    direction: 'in',
+    account: 'Metro Parking Authority',
+    vehicle: '2016 Toyota Camry SE',
+    plate: 'MPA 2197',
+    vin: '4T1BF1FK0GU256718',
+    impoundDate: '2024-09-22',
+    daysHeld: 8,
+    total: 318.0,
+    balanceDue: 0,
+    storageLot: 'Overflow Lot · Row 1 · Space 05',
+    status: 'current',
+    holdReason: 'Awaiting owner payment confirmation.',
+    contact: 'Parking Authority · (313) 555-0178',
+    releaseSteps: 'Payment received, release paperwork signed 09/28.',
+    paymentStatus: 'Paid in full',
+    vehicleColor: 'Silver',
+    vehicleNotes: 'No visible damage. Battery disconnected.'
+  },
+  {
+    id: 'STK-2204',
+    call: 'TB-2059',
+    direction: 'in',
+    account: 'Allied Insurance',
+    vehicle: '2021 Jeep Wrangler Rubicon',
+    plate: 'GZR 1482',
+    vin: '1C4HJXFG4MW611284',
+    impoundDate: '2024-09-27',
+    daysHeld: 3,
+    total: 185.75,
+    balanceDue: 185.75,
+    storageLot: 'Main Lot · Row 7 · Space 02',
+    status: 'stock-in',
+    holdReason: 'Insurance inspection scheduled 10/02.',
+    contact: 'Adjuster Kelly Moore · (248) 555-0134',
+    releaseSteps: 'Release after adjuster sign-off.',
+    paymentStatus: 'Awaiting insurance approval',
+    vehicleColor: 'Granite Crystal',
+    vehicleNotes: 'Soft top secured. Photographed for claim.'
+  },
+  {
+    id: 'STK-2198',
+    call: 'TB-2046',
+    direction: 'out',
+    account: 'Private Property Program',
+    vehicle: '2014 Honda Accord LX',
+    plate: 'BKT 9034',
+    vin: '1HGCR2F3XEA135902',
+    impoundDate: '2024-09-12',
+    daysHeld: 15,
+    total: 512.4,
+    balanceDue: 0,
+    storageLot: 'Released 09/27',
+    status: 'stock-out',
+    holdReason: 'Released to registered owner.',
+    contact: 'Release Agent · Carla Jenkins',
+    releaseSteps: 'Released with signed ID and receipt #90833.',
+    paymentStatus: 'Receipt on file',
+    vehicleColor: 'Black',
+    vehicleNotes: 'Owner verified VIN at release counter.'
+  },
+  {
+    id: 'STK-2189',
+    call: 'TB-2038',
+    direction: 'out',
+    account: 'Detroit Fleet Services',
+    vehicle: '2019 Freightliner M2',
+    plate: 'DFS 4412',
+    vin: '3ALACWDT4KDLP9684',
+    impoundDate: '2024-09-05',
+    daysHeld: 21,
+    total: 786.25,
+    balanceDue: 132.0,
+    storageLot: 'Billing Hold',
+    status: 'account',
+    holdReason: 'Pending billing approval from fleet manager.',
+    contact: 'Accounts Payable · (586) 555-0199',
+    releaseSteps: 'Send invoice and await PO confirmation.',
+    paymentStatus: 'Outstanding balance',
+    vehicleColor: 'White',
+    vehicleNotes: 'Requires jump-start if returned to service.'
+  }
+];
+
+const impoundStatusMeta = {
+  current: { label: 'Active Hold', statusClass: 'status-hold' },
+  'stock-in': { label: 'New Arrival', statusClass: 'status-hold' },
+  'stock-out': { label: 'Released', statusClass: 'status-release' },
+  account: { label: 'Billing Review', statusClass: 'status-billing' }
+};
 
 const reportingMetrics = {
   revenue: '$48,230',
@@ -457,6 +579,23 @@ let currentDispatchFilters = {
 };
 
 let activeDispatchTab = 'view-calls';
+let activeImpoundTab = 'current';
+let activeImpoundId = null;
+let impoundFilters = {
+  query: '',
+  stock: '',
+  call: '',
+  direction: 'all',
+  account: '',
+  vehicle: '',
+  plate: '',
+  vin: '',
+  impoundDate: '',
+  daysHeld: '',
+  total: '',
+  balanceDue: '',
+  storageLot: ''
+};
 let activeDriverId = null;
 let surveyFilters = {
   category: 'all',
@@ -552,6 +691,337 @@ function renderImpounds() {
     fragment.appendChild(item);
   });
   impoundListEl.appendChild(fragment);
+}
+
+function impoundMatchesFilters(record, filters) {
+  const textMatches = (filterValue, recordValue) => {
+    if (!filterValue) return true;
+    return normalizeText(recordValue).includes(filterValue);
+  };
+
+  if (filters.direction !== 'all') {
+    const direction = normalizeText(record.direction);
+    if (direction !== filters.direction) {
+      return false;
+    }
+  }
+
+  if (filters.impoundDate) {
+    const recordDate = record.impoundDate?.slice(0, 10);
+    if (recordDate !== filters.impoundDate) {
+      return false;
+    }
+  }
+
+  if (filters.daysHeld) {
+    const minDays = Number(filters.daysHeld);
+    if (!Number.isNaN(minDays) && Number(record.daysHeld) < minDays) {
+      return false;
+    }
+  }
+
+  if (filters.total) {
+    const minTotal = Number(filters.total);
+    if (!Number.isNaN(minTotal) && Number(record.total) < minTotal) {
+      return false;
+    }
+  }
+
+  if (filters.balanceDue) {
+    const minBalance = Number(filters.balanceDue);
+    if (!Number.isNaN(minBalance) && Number(record.balanceDue) < minBalance) {
+      return false;
+    }
+  }
+
+  if (!textMatches(filters.stock, record.id)) return false;
+  if (!textMatches(filters.call, record.call)) return false;
+  if (!textMatches(filters.account, record.account)) return false;
+  if (!textMatches(filters.vehicle, record.vehicle)) return false;
+  if (!textMatches(filters.plate, record.plate)) return false;
+  if (!textMatches(filters.vin, record.vin)) return false;
+  if (!textMatches(filters.storageLot, record.storageLot)) return false;
+
+  if (filters.query) {
+    const haystack = [
+      record.id,
+      record.call,
+      record.account,
+      record.vehicle,
+      record.plate,
+      record.vin,
+      record.storageLot,
+      record.holdReason,
+      record.contact
+    ]
+      .filter(Boolean)
+      .map((value) => normalizeText(value))
+      .join(' ');
+
+    if (!haystack.includes(filters.query)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function getFilteredImpounds() {
+  return impoundLotRecords
+    .filter((record) => {
+      const tab = record.status ?? 'current';
+      return activeImpoundTab === tab;
+    })
+    .filter((record) => impoundMatchesFilters(record, impoundFilters));
+}
+
+function renderImpoundTable() {
+  if (!impoundTableBodyEl) return;
+
+  impoundTableBodyEl.innerHTML = '';
+
+  const filtered = getFilteredImpounds().sort((a, b) => {
+    const aTime = new Date(a.impoundDate).valueOf();
+    const bTime = new Date(b.impoundDate).valueOf();
+    if (Number.isNaN(aTime) || Number.isNaN(bTime)) {
+      return 0;
+    }
+    return bTime - aTime;
+  });
+
+  if (!filtered.length) {
+    const emptyRow = document.createElement('tr');
+    emptyRow.className = 'impound-empty-row';
+    emptyRow.innerHTML = '<td colspan="12" class="empty">No impounds found.</td>';
+    impoundTableBodyEl.appendChild(emptyRow);
+    activeImpoundId = null;
+    renderImpoundDetail(null);
+    return;
+  }
+
+  let activeRecord = null;
+
+  filtered.forEach((record) => {
+    const row = document.createElement('tr');
+    row.innerHTML = `
+      <td>${record.id}</td>
+      <td>${record.call}</td>
+      <td>${record.direction === 'in' ? 'In' : 'Out'}</td>
+      <td>${record.account}</td>
+      <td>${record.vehicle}</td>
+      <td>${record.plate}</td>
+      <td>${record.vin}</td>
+      <td>${formatDateOnly(record.impoundDate)}</td>
+      <td>${record.daysHeld}</td>
+      <td>${formatCurrency(record.total)}</td>
+      <td>${formatCurrency(record.balanceDue)}</td>
+      <td>${record.storageLot}</td>
+    `;
+
+    if (record.id === activeImpoundId) {
+      row.classList.add('selected');
+      activeRecord = record;
+    }
+
+    row.addEventListener('click', () => {
+      activeImpoundId = activeImpoundId === record.id ? null : record.id;
+      renderImpoundTable();
+    });
+
+    impoundTableBodyEl.appendChild(row);
+  });
+
+  if (activeImpoundId && !activeRecord) {
+    activeImpoundId = null;
+    renderImpoundDetail(null);
+  } else if (activeRecord) {
+    renderImpoundDetail(activeRecord);
+  } else {
+    renderImpoundDetail(null);
+  }
+}
+
+function renderImpoundDetail(record) {
+  if (!impoundDetailEl) return;
+
+  if (!record) {
+    impoundDetailEl.innerHTML = `
+      <div class="impound-empty-state">
+        <h2>No impound selected</h2>
+        <p>Select a vehicle from the list to view storage details and next steps.</p>
+      </div>
+    `;
+    return;
+  }
+
+  const statusMeta = impoundStatusMeta[record.status] ?? {
+    label: 'Active',
+    statusClass: 'status-hold'
+  };
+
+  const primaryActionLabel =
+    record.status === 'stock-out' ? 'View Release Paperwork' : 'Start Release';
+  const secondaryActionLabel =
+    record.status === 'account' ? 'Update Billing' : 'Print Receipt';
+
+  impoundDetailEl.innerHTML = `
+    <header class="impound-detail-header">
+      <div>
+        <h2>${record.vehicle}</h2>
+        <div class="impound-detail-meta">
+          <span>Stock ${record.id}</span>
+          <span>Call ${record.call}</span>
+          <span>Impounded ${formatDateOnly(record.impoundDate)}</span>
+        </div>
+      </div>
+      <span class="status-chip ${statusMeta.statusClass}">${statusMeta.label}</span>
+    </header>
+    <dl class="impound-detail-grid">
+      <div>
+        <dt>Account</dt>
+        <dd>${record.account}</dd>
+      </div>
+      <div>
+        <dt>Plate</dt>
+        <dd>${record.plate}</dd>
+      </div>
+      <div>
+        <dt>VIN</dt>
+        <dd>${record.vin}</dd>
+      </div>
+      <div>
+        <dt>Storage Location</dt>
+        <dd>${record.storageLot}</dd>
+      </div>
+      <div>
+        <dt>Days Held</dt>
+        <dd>${record.daysHeld}</dd>
+      </div>
+      <div>
+        <dt>Total Charges</dt>
+        <dd>${formatCurrency(record.total)}</dd>
+      </div>
+      <div>
+        <dt>Balance Due</dt>
+        <dd>${formatCurrency(record.balanceDue)}</dd>
+      </div>
+      <div>
+        <dt>Payment Status</dt>
+        <dd>${record.paymentStatus ?? '—'}</dd>
+      </div>
+      <div>
+        <dt>Vehicle Color</dt>
+        <dd>${record.vehicleColor ?? '—'}</dd>
+      </div>
+      <div>
+        <dt>Primary Contact</dt>
+        <dd>${record.contact ?? '—'}</dd>
+      </div>
+    </dl>
+    <div class="impound-detail-notes">
+      <p><strong>Hold Reason:</strong> ${record.holdReason ?? '—'}</p>
+      <p><strong>Next Steps:</strong> ${record.releaseSteps ?? '—'}</p>
+      <p><strong>Notes:</strong> ${record.vehicleNotes ?? '—'}</p>
+    </div>
+    <div class="impound-detail-actions">
+      <button type="button" class="primary-action">${primaryActionLabel}</button>
+      <button type="button" class="secondary-action">${secondaryActionLabel}</button>
+      <button type="button" class="link-action">View History</button>
+    </div>
+  `;
+}
+
+function setActiveImpoundTab(tabId, { force = false } = {}) {
+  if (!tabId) return;
+  if (!force && activeImpoundTab === tabId) {
+    return;
+  }
+
+  activeImpoundTab = tabId;
+
+  impoundTabButtons.forEach((button) => {
+    const isActive = button.dataset.impoundTab === tabId;
+    button.classList.toggle('active', isActive);
+    button.setAttribute('aria-selected', isActive ? 'true' : 'false');
+  });
+
+  activeImpoundId = null;
+  renderImpoundTable();
+}
+
+function handleImpoundFilterInput(event) {
+  const target = event.target;
+  if (!(target instanceof HTMLInputElement || target instanceof HTMLSelectElement)) {
+    return;
+  }
+
+  const key = target.dataset.impoundFilter;
+  if (!key || !(key in impoundFilters)) {
+    return;
+  }
+
+  let value = target.value ?? '';
+
+  if (target.type === 'text' || target.type === 'search') {
+    value = normalizeText(value);
+  } else if (target instanceof HTMLSelectElement) {
+    value = value.trim().toLowerCase();
+  } else if (target.type === 'number') {
+    value = value.trim();
+  }
+
+  if (key === 'direction' && !value) {
+    value = 'all';
+  }
+
+  impoundFilters[key] = value;
+  renderImpoundTable();
+}
+
+function initImpoundModule() {
+  if (!impoundTableBodyEl || !impoundDetailEl) return;
+
+  let renderedFromTab = false;
+
+  if (impoundTabButtons.length) {
+    impoundTabButtons.forEach((button) => {
+      button.addEventListener('click', () => {
+        const tabId = button.dataset.impoundTab;
+        if (tabId) {
+          setActiveImpoundTab(tabId);
+        }
+      });
+    });
+    setActiveImpoundTab(activeImpoundTab, { force: true });
+    renderedFromTab = true;
+  }
+
+  if (impoundFilterInputs.length) {
+    impoundFilterInputs.forEach((input) => {
+      const eventName = input.tagName === 'SELECT' || input.type === 'date' || input.type === 'number' ? 'change' : 'input';
+      input.addEventListener(eventName, handleImpoundFilterInput);
+    });
+  }
+
+  if (impoundSearchFormEl) {
+    impoundSearchFormEl.addEventListener('submit', (event) => {
+      event.preventDefault();
+      const queryValue = normalizeText(impoundSearchInputEl?.value ?? '');
+      impoundFilters.query = queryValue;
+      renderImpoundTable();
+    });
+
+    impoundSearchFormEl.addEventListener('reset', () => {
+      setTimeout(() => {
+        impoundFilters.query = '';
+        renderImpoundTable();
+      }, 0);
+    });
+  }
+
+  if (!renderedFromTab) {
+    renderImpoundTable();
+  }
 }
 
 function renderReports() {
@@ -660,11 +1130,29 @@ function formatDateTime(value) {
   return `${datePart} · ${timePart}`;
 }
 
+function formatDateOnly(value) {
+  if (!value) return '';
+  const date = new Date(value);
+  if (Number.isNaN(date.valueOf())) return value;
+  return date.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' });
+}
+
 function formatTimeOnly(value) {
   if (!value) return '';
   const date = new Date(value);
   if (Number.isNaN(date.valueOf())) return value;
   return date.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
+}
+
+function formatCurrency(value) {
+  if (value === null || value === undefined || value === '') {
+    return '—';
+  }
+  const number = Number(value);
+  if (Number.isNaN(number)) {
+    return value;
+  }
+  return new Intl.NumberFormat(undefined, { style: 'currency', currency: 'USD' }).format(number);
 }
 
 function renderCallRows(status, calls) {
@@ -1058,7 +1546,7 @@ function initNavigation() {
     link.addEventListener('click', (event) => {
       event.preventDefault();
       const target = link.dataset.viewTarget;
-      if (target === 'dashboard' || target === 'dispatching') {
+      if (target) {
         setActiveView(target);
       }
     });
@@ -1196,6 +1684,7 @@ function init() {
   setActiveDispatchTab(activeDispatchTab);
   renderDashboard();
   renderDispatchingModule();
+  initImpoundModule();
   initNavigation();
   initDashboardEvents();
   initDispatchEvents();

--- a/styles.css
+++ b/styles.css
@@ -4,6 +4,7 @@
   --blue-050: #f1f6fb;
   --gray-025: #f8f9fb;
   --gray-050: #eef1f5;
+  --gray-075: #e6eaef;
   --gray-100: #dfe4ea;
   --gray-400: #7b8794;
   --gray-500: #4d5766;
@@ -343,6 +344,21 @@ body {
   color: var(--red-500);
 }
 
+.status-hold {
+  background: rgba(29, 108, 198, 0.12);
+  color: var(--blue-600);
+}
+
+.status-release {
+  background: rgba(47, 157, 77, 0.12);
+  color: var(--green-500);
+}
+
+.status-billing {
+  background: rgba(255, 138, 76, 0.12);
+  color: var(--orange-500);
+}
+
 .grid-panels {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
@@ -416,6 +432,266 @@ body {
   color: var(--gray-900);
   font-size: 1.6rem;
   margin-bottom: 0.35rem;
+}
+
+.impound-view {
+  padding: 2.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+}
+
+.impound-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1.5rem 2rem;
+  background: #fff;
+  border-radius: 16px;
+  padding: 1.75rem 2rem;
+  box-shadow: var(--shadow-sm);
+}
+
+.impound-heading h1 {
+  font-size: 1.6rem;
+  color: var(--gray-900);
+  margin: 0 0 0.4rem;
+}
+
+.impound-heading p {
+  margin: 0;
+  color: var(--gray-400);
+  max-width: 560px;
+}
+
+.impound-actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.impound-report-action {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.impound-report-action .chevron {
+  font-size: 0.75rem;
+  color: var(--gray-300);
+}
+
+.impound-toolbar {
+  background: #fff;
+  border-radius: 16px;
+  box-shadow: var(--shadow-sm);
+  padding: 1rem 1.5rem;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 1rem;
+  justify-content: space-between;
+}
+
+.impound-tabs {
+  display: flex;
+  gap: 0.35rem;
+  flex-wrap: wrap;
+}
+
+.impound-tab {
+  border: none;
+  background: transparent;
+  padding: 0.5rem 1rem;
+  border-radius: 999px;
+  font-weight: 600;
+  color: var(--gray-400);
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.impound-tab:hover {
+  background: var(--gray-050);
+  color: var(--gray-500);
+}
+
+.impound-tab.active {
+  background: rgba(29, 108, 198, 0.12);
+  color: var(--blue-600);
+}
+
+.impound-search {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-left: auto;
+}
+
+.impound-search input[type='search'] {
+  border: 1px solid var(--gray-100);
+  border-radius: 999px;
+  padding: 0.55rem 1rem;
+  min-width: 220px;
+}
+
+.impound-search-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.impound-lot {
+  display: grid;
+  grid-template-columns: minmax(0, 2.1fr) minmax(260px, 1fr);
+  gap: 1.5rem;
+  align-items: flex-start;
+}
+
+.impound-table-wrapper {
+  background: #fff;
+  border-radius: 16px;
+  box-shadow: var(--shadow-sm);
+  overflow: hidden;
+}
+
+.impound-table {
+  font-size: 0.85rem;
+}
+
+.impound-table thead tr.impound-filter-row {
+  background: #fff;
+  text-transform: none;
+  letter-spacing: normal;
+  color: var(--gray-500);
+  border-top: 1px solid var(--gray-075);
+}
+
+.impound-table thead tr.impound-filter-row th {
+  padding: 0.5rem 0.75rem;
+}
+
+.impound-table thead tr.impound-filter-row input,
+.impound-table thead tr.impound-filter-row select {
+  width: 100%;
+  border: 1px solid var(--gray-100);
+  border-radius: 8px;
+  padding: 0.4rem 0.5rem;
+  font-size: 0.8rem;
+  color: var(--gray-500);
+  background: var(--gray-025);
+}
+
+.impound-table tbody tr {
+  cursor: pointer;
+  transition: background 0.2s ease, box-shadow 0.2s ease;
+}
+
+.impound-table tbody tr:hover {
+  background: rgba(29, 108, 198, 0.08);
+}
+
+.impound-table tbody tr.impound-empty-row {
+  cursor: default;
+}
+
+.impound-table tbody tr.impound-empty-row:hover {
+  background: inherit;
+}
+
+.impound-table tbody tr.selected {
+  background: rgba(29, 108, 198, 0.16);
+  box-shadow: inset 0 0 0 1px rgba(29, 108, 198, 0.3);
+}
+
+.impound-detail {
+  background: #fff;
+  border-radius: 16px;
+  box-shadow: var(--shadow-sm);
+  padding: 1.5rem 1.75rem;
+  min-height: 420px;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.impound-empty-state {
+  margin: auto 0;
+  text-align: center;
+  display: grid;
+  gap: 0.5rem;
+  color: var(--gray-400);
+}
+
+.impound-empty-state h2 {
+  margin: 0;
+  color: var(--gray-600);
+  font-size: 1.1rem;
+}
+
+.impound-detail-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.impound-detail-header h2 {
+  margin: 0;
+  color: var(--gray-900);
+  font-size: 1.2rem;
+}
+
+.impound-detail-meta {
+  display: flex;
+  gap: 1.25rem;
+  flex-wrap: wrap;
+  font-size: 0.85rem;
+  color: var(--gray-400);
+}
+
+.impound-detail-grid {
+  display: grid;
+  gap: 1rem 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.impound-detail-grid dt {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--gray-400);
+  margin-bottom: 0.25rem;
+}
+
+.impound-detail-grid dd {
+  margin: 0;
+  color: var(--gray-700);
+  font-weight: 500;
+}
+
+.impound-detail-notes {
+  border-top: 1px solid var(--gray-075);
+  padding-top: 1rem;
+  color: var(--gray-500);
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+
+.impound-detail-actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.impound-detail .status-chip {
+  font-size: 0.75rem;
+}
+
+@media (max-width: 1024px) {
+  .impound-lot {
+    grid-template-columns: 1fr;
+  }
 }
 
 .dispatch-meta {


### PR DESCRIPTION
## Summary
- add a dedicated Impound Lot view with toolbar actions, filterable table, and detail panel
- style the impound management experience to match the Towbook Cloud visual language
- implement impound data set, filtering, tab navigation, and detail rendering with selection persistence

## Testing
- No automated tests (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dd451af85c83299f2fc27a2238bae9