### PR TITLE
Add impound management view and modal form

### DIFF
--- a/index.html
+++ b/index.html
@@ -336,6 +336,52 @@
         </section>
       </main>
 
+      <main class="view impound-view" data-view="impounds" hidden>
+        <section class="impound-header">
+          <div>
+            <h1>Impound Management</h1>
+            <p>Monitor yard inventory, manage holds, and register new impounds.</p>
+          </div>
+          <div class="impound-header-actions">
+            <button class="primary-action" id="new-impound-button">New Impound</button>
+          </div>
+        </section>
+
+        <div class="impound-alert" id="impound-alert" role="status" hidden></div>
+
+        <section class="impound-inventory">
+          <header class="section-heading">
+            <h2 id="impound-inventory-heading">Current Inventory</h2>
+            <div class="impound-tools">
+              <label class="sr-only" for="impound-search">Search impounds</label>
+              <input
+                id="impound-search"
+                class="impound-search"
+                type="search"
+                placeholder="Search impound number, owner, or vehicle"
+              />
+            </div>
+          </header>
+          <div class="inventory-table">
+            <table class="data-table" aria-labelledby="impound-inventory-heading">
+              <thead>
+                <tr>
+                  <th scope="col">Impound #</th>
+                  <th scope="col">Vehicle</th>
+                  <th scope="col">Owner</th>
+                  <th scope="col">Reason</th>
+                  <th scope="col">Priority</th>
+                  <th scope="col">Release</th>
+                  <th scope="col">Status</th>
+                </tr>
+              </thead>
+              <tbody id="impound-table-body"></tbody>
+            </table>
+            <p class="empty" data-impound-empty hidden>No impounds registered yet.</p>
+          </div>
+        </section>
+      </main>
+
       <footer class="footer">
         <div>© 2024 Towbook Cloud. All rights reserved.</div>
         <div class="footer-links">
@@ -344,6 +390,221 @@
           <a href="#">Support</a>
         </div>
       </footer>
+    </div>
+
+    <div class="impound-modal" id="new-impound-modal" hidden>
+      <div class="impound-modal__backdrop" data-close-impound></div>
+      <div class="impound-dialog" role="dialog" aria-modal="true" aria-labelledby="new-impound-title">
+        <header class="impound-dialog__header">
+          <div class="impound-dialog__title">
+            <p class="impound-dialog__meta">User Editing: <strong>Tsedeke Girma</strong></p>
+            <h2 id="new-impound-title">New Impound</h2>
+          </div>
+          <button type="button" class="icon-button" data-close-impound aria-label="Close new impound form">
+            ✕
+          </button>
+        </header>
+        <form class="impound-form" id="impound-form">
+          <div class="impound-dialog__body">
+            <div class="segmented-control" role="group" aria-label="Call type">
+              <button type="button" class="segmented-control__option is-active" data-impound-mode="new">New Call</button>
+              <button type="button" class="segmented-control__option" data-impound-mode="completed">Completed Call</button>
+              <button type="button" class="segmented-control__option" data-impound-mode="scheduled">Schedule a Call</button>
+              <button type="button" class="segmented-control__option" data-impound-mode="quote">Quote</button>
+            </div>
+
+            <section class="impound-form-section">
+              <header class="impound-form-section__header">
+                <h3>Call Information</h3>
+                <div class="impound-form-section__meta">Account · Contact · Logistics</div>
+              </header>
+              <div class="impound-form-grid">
+                <label class="form-field" for="impound-account">
+                  Account
+                  <input id="impound-account" name="account" type="text" placeholder="Select or enter account" />
+                </label>
+                <label class="form-field" for="impound-contact-name">
+                  Contact name
+                  <input id="impound-contact-name" name="contactName" type="text" placeholder="Name on scene" />
+                </label>
+                <label class="form-field" for="impound-contact-phone">
+                  Phone number
+                  <input id="impound-contact-phone" name="contactPhone" type="tel" placeholder="(000) 000-0000" />
+                </label>
+                <label class="form-field" for="impound-number">
+                  Impound #
+                  <input id="impound-number" name="impoundNumber" type="text" placeholder="INV-0000" />
+                </label>
+                <label class="form-field span-2" for="impound-pickup">
+                  Pickup location
+                  <input id="impound-pickup" name="pickupLocation" type="text" placeholder="Property, cross streets, or GPS" />
+                </label>
+                <label class="form-field" for="impound-destination">
+                  Destination
+                  <select id="impound-destination" name="destination">
+                    <option value="usp-holding">USP Holding</option>
+                    <option value="north-yard">North Yard</option>
+                    <option value="east-lot">East Lot</option>
+                    <option value="central-storage">Central Storage</option>
+                  </select>
+                </label>
+                <label class="form-field" for="impound-reason">
+                  Impound reason
+                  <select id="impound-reason" name="impoundReason">
+                    <option value="police-hold">Police Hold</option>
+                    <option value="private-property">Private Property</option>
+                    <option value="abandoned">Abandoned Vehicle</option>
+                    <option value="tow-away">Tow Away Zone</option>
+                    <option value="evidence">Evidence</option>
+                  </select>
+                </label>
+                <label class="form-field" for="impound-invoice">
+                  Invoice #
+                  <input id="impound-invoice" name="invoiceNumber" type="text" placeholder="Automatically generated if left blank" />
+                </label>
+                <label class="form-field" for="impound-eta">
+                  ETA
+                  <input id="impound-eta" name="eta" type="text" placeholder="e.g., 30 min" />
+                </label>
+                <label class="form-field" for="impound-priority">
+                  Priority
+                  <select id="impound-priority" name="priority">
+                    <option value="Normal">Normal</option>
+                    <option value="High">High</option>
+                    <option value="Emergency">Emergency</option>
+                  </select>
+                </label>
+                <div class="form-field form-field--inline">
+                  <span>Emergency</span>
+                  <label class="checkbox-field" for="impound-emergency">
+                    <input id="impound-emergency" name="isEmergency" type="checkbox" value="yes" />
+                    <span>Mark as emergency</span>
+                  </label>
+                </div>
+                <label class="form-field span-2" for="impound-notes">
+                  Incident notes
+                  <textarea
+                    id="impound-notes"
+                    name="notes"
+                    rows="3"
+                    placeholder="Damage, instructions, or incident details"
+                  ></textarea>
+                </label>
+              </div>
+            </section>
+
+            <section class="impound-form-section">
+              <header class="impound-form-section__header">
+                <h3>Vehicle Information</h3>
+                <div class="impound-form-section__meta">Vehicle, owner, keys, and condition</div>
+              </header>
+              <div class="impound-form-grid">
+                <label class="form-field" for="vehicle-license">
+                  License/VIN
+                  <input id="vehicle-license" name="license" type="text" placeholder="Plate or VIN" />
+                </label>
+                <label class="form-field" for="vehicle-state">
+                  State
+                  <select id="vehicle-state" name="state">
+                    <option value="MI">MI</option>
+                    <option value="IL">IL</option>
+                    <option value="OH">OH</option>
+                    <option value="WI">WI</option>
+                    <option value="IN">IN</option>
+                  </select>
+                </label>
+                <label class="form-field" for="vehicle-year">
+                  Year
+                  <input id="vehicle-year" name="vehicleYear" type="number" min="1950" max="2099" placeholder="2022" />
+                </label>
+                <label class="form-field" for="vehicle-make">
+                  Make
+                  <input id="vehicle-make" name="vehicleMake" type="text" placeholder="Ford" />
+                </label>
+                <label class="form-field" for="vehicle-model">
+                  Model
+                  <input id="vehicle-model" name="vehicleModel" type="text" placeholder="Explorer" />
+                </label>
+                <label class="form-field" for="vehicle-color">
+                  Color
+                  <input id="vehicle-color" name="vehicleColor" type="text" placeholder="Blue" />
+                </label>
+                <label class="form-field" for="vehicle-type">
+                  Vehicle type
+                  <select id="vehicle-type" name="vehicleType">
+                    <option value="Light">Light Duty</option>
+                    <option value="Medium">Medium Duty</option>
+                    <option value="Heavy">Heavy Duty</option>
+                  </select>
+                </label>
+                <label class="form-field" for="vehicle-drive">
+                  Drive condition
+                  <select id="vehicle-drive" name="driveCondition">
+                    <option value="drivable">Drivable</option>
+                    <option value="inoperable">Inoperable</option>
+                    <option value="unknown">Unknown</option>
+                  </select>
+                </label>
+                <label class="form-field" for="vehicle-owner">
+                  Owner
+                  <input id="vehicle-owner" name="ownerName" type="text" placeholder="Registered owner" />
+                </label>
+                <label class="form-field" for="vehicle-owner-phone">
+                  Owner phone
+                  <input id="vehicle-owner-phone" name="ownerPhone" type="tel" placeholder="(000) 000-0000" />
+                </label>
+                <div class="form-field form-field--inline">
+                  <span>Keys</span>
+                  <label class="checkbox-field" for="vehicle-has-keys">
+                    <input id="vehicle-has-keys" name="hasKeys" type="checkbox" value="yes" />
+                    <span>Keys received</span>
+                  </label>
+                </div>
+                <label class="form-field" for="vehicle-location">
+                  Yard location
+                  <input id="vehicle-location" name="yardLocation" type="text" placeholder="Row, lot, or zone" />
+                </label>
+                <label class="form-field" for="release-status">
+                  Release status
+                  <div class="radio-field" id="release-status">
+                    <label>
+                      <input type="radio" name="releaseStatus" value="Pending Release" checked />
+                      Pending release
+                    </label>
+                    <label>
+                      <input type="radio" name="releaseStatus" value="Ready for release" />
+                      Ready for release
+                    </label>
+                  </div>
+                </label>
+                <label class="form-field span-2" for="vehicle-notes">
+                  Vehicle notes
+                  <textarea
+                    id="vehicle-notes"
+                    name="vehicleNotes"
+                    rows="3"
+                    placeholder="Damage, inventory, or officer notes"
+                  ></textarea>
+                </label>
+              </div>
+            </section>
+          </div>
+
+          <footer class="impound-dialog__footer">
+            <div class="impound-dialog__footer-meta">
+              <div class="checkbox-field">
+                <input id="impound-send-sms" name="sendSms" type="checkbox" value="yes" />
+                <label for="impound-send-sms">Send SMS confirmation to owner</label>
+              </div>
+              <div id="impound-form-feedback" class="impound-form-feedback" role="status" aria-live="polite"></div>
+            </div>
+            <div class="impound-dialog__footer-actions">
+              <button type="button" class="secondary-action" data-close-impound>Cancel</button>
+              <button type="submit" class="primary-action">Create Impound</button>
+            </div>
+          </footer>
+        </form>
+      </div>
     </div>
 
     <script src="script.js" type="module"></script>

--- a/index.html
+++ b/index.html
@@ -90,7 +90,7 @@
         </section>
 
         <div class="grid-panels">
-          <section class="panel" id="impounds">
+          <section class="panel" id="dashboard-impounds">
             <header class="section-heading">
               <h2>Impound Yard Snapshot</h2>
               <a class="link" href="#">View All</a>

--- a/styles.css
+++ b/styles.css
@@ -1050,3 +1050,406 @@ button:disabled,
     gap: 0.75rem;
   }
 }
+
+.impound-view {
+  padding: 2.5rem;
+  display: grid;
+  gap: 2rem;
+}
+
+.impound-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1.5rem;
+}
+
+.impound-header h1 {
+  color: var(--gray-900);
+  font-size: 1.6rem;
+  margin-bottom: 0.35rem;
+}
+
+.impound-header p {
+  color: var(--gray-400);
+  max-width: 36rem;
+}
+
+.impound-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.impound-alert {
+  background: rgba(47, 157, 77, 0.12);
+  border: 1px solid rgba(47, 157, 77, 0.45);
+  color: var(--green-500);
+  padding: 0.85rem 1.2rem;
+  border-radius: 12px;
+  font-weight: 500;
+  box-shadow: var(--shadow-sm);
+}
+
+.impound-inventory {
+  background: #fff;
+  border-radius: 16px;
+  padding: 1.75rem 2rem;
+  box-shadow: var(--shadow-sm);
+  display: grid;
+  gap: 1.5rem;
+}
+
+.impound-tools {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.impound-search {
+  border: 1px solid var(--gray-100);
+  border-radius: 10px;
+  padding: 0.6rem 0.9rem;
+  font-size: 0.95rem;
+  color: var(--gray-500);
+  min-width: 240px;
+}
+
+.impound-search:focus {
+  outline: 2px solid rgba(29, 108, 198, 0.25);
+  border-color: var(--blue-500);
+}
+
+.inventory-table {
+  border: 1px solid var(--gray-100);
+  border-radius: 14px;
+  overflow: hidden;
+  background: #fff;
+}
+
+.inventory-table .data-table tbody tr:nth-of-type(even) {
+  background: rgba(241, 246, 251, 0.45);
+}
+
+.inventory-table .data-table tbody tr:hover {
+  background: rgba(241, 246, 251, 0.8);
+}
+
+[data-impound-empty] {
+  padding: 1.75rem;
+  color: var(--gray-400);
+  font-style: italic;
+  text-align: center;
+}
+
+.impound-vehicle {
+  color: var(--gray-900);
+  font-weight: 600;
+}
+
+.impound-meta {
+  font-size: 0.8rem;
+  color: var(--gray-400);
+  margin-top: 0.2rem;
+}
+
+.impound-owner {
+  color: var(--gray-900);
+  font-weight: 600;
+}
+
+.impound-owner-meta {
+  font-size: 0.8rem;
+  color: var(--gray-400);
+  margin-top: 0.2rem;
+}
+
+.status-holding {
+  background: rgba(29, 108, 198, 0.12);
+  color: var(--blue-500);
+}
+
+.status-ready {
+  background: rgba(47, 157, 77, 0.18);
+  color: var(--green-500);
+}
+
+.status-awaiting {
+  background: rgba(255, 138, 76, 0.16);
+  color: var(--orange-500);
+}
+
+.status-released {
+  background: rgba(79, 90, 104, 0.18);
+  color: var(--gray-500);
+}
+
+body.modal-open {
+  overflow: hidden;
+}
+
+.impound-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 900;
+  display: grid;
+}
+
+.impound-modal[hidden] {
+  display: none;
+}
+
+.impound-modal__backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(17, 24, 39, 0.55);
+  backdrop-filter: blur(3px);
+}
+
+.impound-dialog {
+  position: relative;
+  margin: 3rem auto;
+  width: min(1040px, calc(100% - 2.5rem));
+  background: #fff;
+  border-radius: 18px;
+  box-shadow: 0 32px 64px rgba(15, 23, 42, 0.25);
+  display: flex;
+  flex-direction: column;
+  max-height: calc(100vh - 4rem);
+  overflow: hidden;
+}
+
+.impound-dialog__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  padding: 1.5rem 2rem 1rem;
+  border-bottom: 1px solid var(--gray-100);
+  gap: 1rem;
+}
+
+.impound-dialog__meta {
+  font-size: 0.85rem;
+  color: var(--gray-400);
+}
+
+.impound-dialog__title h2 {
+  font-size: 1.45rem;
+  color: var(--gray-900);
+  margin-top: 0.4rem;
+}
+
+.icon-button {
+  border: none;
+  background: transparent;
+  font-size: 1.5rem;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0.25rem;
+  border-radius: 999px;
+  color: var(--gray-400);
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.icon-button:hover,
+.icon-button:focus-visible {
+  background: var(--gray-050);
+  color: var(--gray-500);
+  outline: none;
+}
+
+.impound-dialog__body {
+  padding: 1.5rem 2rem;
+  overflow-y: auto;
+  display: grid;
+  gap: 1.75rem;
+}
+
+.segmented-control {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  background: var(--gray-050);
+  border-radius: 14px;
+  padding: 0.35rem;
+  box-shadow: inset 0 0 0 1px var(--gray-100);
+}
+
+.segmented-control__option {
+  border: none;
+  background: transparent;
+  padding: 0.55rem 1.1rem;
+  border-radius: 12px;
+  font-weight: 600;
+  color: var(--gray-400);
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.segmented-control__option.is-active {
+  background: #fff;
+  color: var(--blue-500);
+  box-shadow: var(--shadow-sm);
+}
+
+.segmented-control__option:focus-visible {
+  outline: 2px solid rgba(29, 108, 198, 0.4);
+  outline-offset: 2px;
+}
+
+.impound-form-section {
+  display: grid;
+  gap: 1rem;
+}
+
+.impound-form-section__header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.impound-form-section__header h3 {
+  color: var(--gray-900);
+  font-size: 1.1rem;
+}
+
+.impound-form-section__meta {
+  font-size: 0.85rem;
+  color: var(--gray-400);
+}
+
+.impound-form-grid {
+  display: grid;
+  gap: 1rem 1.25rem;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.impound-form-grid .span-2 {
+  grid-column: span 2;
+}
+
+.form-field--inline {
+  align-self: end;
+  gap: 0.5rem;
+}
+
+.form-field--inline > span {
+  font-weight: 600;
+  color: var(--gray-500);
+}
+
+.checkbox-field {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+  color: var(--gray-500);
+}
+
+.checkbox-field > label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer;
+}
+
+.checkbox-field span {
+  font-weight: 500;
+}
+
+.checkbox-field input[type='checkbox'] {
+  width: 18px;
+  height: 18px;
+}
+
+.radio-field {
+  display: grid;
+  gap: 0.35rem;
+  font-size: 0.9rem;
+  color: var(--gray-500);
+}
+
+.radio-field label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.radio-field input[type='radio'] {
+  width: 18px;
+  height: 18px;
+}
+
+.impound-dialog__footer {
+  border-top: 1px solid var(--gray-100);
+  padding: 1.25rem 2rem;
+  background: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+}
+
+.impound-dialog__footer-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+  color: var(--gray-400);
+}
+
+.impound-form-feedback {
+  min-height: 1.1rem;
+  font-weight: 500;
+  color: var(--blue-500);
+}
+
+.impound-dialog__footer-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+@media (max-width: 900px) {
+  .impound-form-grid .span-2 {
+    grid-column: span 1;
+  }
+
+  .impound-dialog {
+    margin: 2.5rem auto;
+    width: min(960px, calc(100% - 1.5rem));
+  }
+
+  .impound-dialog__body {
+    padding: 1.5rem;
+  }
+
+  .impound-dialog__footer {
+    padding: 1.25rem 1.5rem;
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .impound-dialog__footer-actions {
+    justify-content: flex-end;
+  }
+}
+
+@media (max-width: 640px) {
+  .impound-header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .impound-header-actions {
+    justify-content: flex-start;
+  }
+
+  .segmented-control {
+    width: 100%;
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+}
+


### PR DESCRIPTION
## Summary
- add a dedicated impound management view with searchable inventory table and call-to-action
- create a full "New Impound" modal form that captures call and vehicle information for new impounds
- expand impound data rendering, filtering, and styles to support form submissions, alerts, and modal interactions

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dd462c94908329bcd749f4a42edd77