### PR TITLE
Add modal workflow for creating impounds

### DIFF
--- a/index.html
+++ b/index.html
@@ -343,7 +343,7 @@
             <p>Track vehicles on hold, view balances, and manage release requests.</p>
           </div>
           <div class="impound-actions">
-            <button type="button" class="primary-action">New Impound</button>
+            <button type="button" class="primary-action" id="new-impound-button">New Impound</button>
             <button type="button" class="secondary-action impound-report-action">
               Create Report
               <span aria-hidden="true" class="chevron">▾</span>
@@ -463,6 +463,77 @@
           <a href="#">Support</a>
         </div>
       </footer>
+    </div>
+
+    <div class="modal" id="new-impound-modal" hidden aria-hidden="true">
+      <div class="modal-dialog" role="dialog" aria-modal="true" aria-labelledby="new-impound-title">
+        <header class="modal-header">
+          <div>
+            <h2 id="new-impound-title">New Impound</h2>
+            <p class="modal-subtitle">Record vehicle intake details to create a new impound entry.</p>
+          </div>
+          <button type="button" class="modal-close" aria-label="Close" data-modal-dismiss>&times;</button>
+        </header>
+        <form class="new-impound-form">
+          <div class="modal-body">
+            <div class="new-impound-grid">
+              <div class="form-field">
+                <label for="new-impound-stock">Stock #</label>
+                <input id="new-impound-stock" name="stockNumber" type="text" placeholder="STK-2301" />
+              </div>
+              <div class="form-field">
+                <label for="new-impound-call">Call #</label>
+                <input id="new-impound-call" name="callNumber" type="text" placeholder="TB-2105" />
+              </div>
+              <div class="form-field">
+                <label for="new-impound-direction">Direction</label>
+                <select id="new-impound-direction" name="direction">
+                  <option value="in">Stock In</option>
+                  <option value="out">Stock Out</option>
+                  <option value="hold">Hold / Account</option>
+                </select>
+              </div>
+              <div class="form-field">
+                <label for="new-impound-account">Account</label>
+                <input id="new-impound-account" name="account" type="text" placeholder="City of Detroit PD" />
+              </div>
+              <div class="form-field">
+                <label for="new-impound-vehicle">Vehicle</label>
+                <input id="new-impound-vehicle" name="vehicle" type="text" placeholder="2018 Ford Explorer" />
+              </div>
+              <div class="form-field">
+                <label for="new-impound-plate">Plate</label>
+                <input id="new-impound-plate" name="plate" type="text" placeholder="PDX 4287" />
+              </div>
+              <div class="form-field">
+                <label for="new-impound-vin">VIN</label>
+                <input id="new-impound-vin" name="vin" type="text" placeholder="1FM5K8AR7JGA42158" />
+              </div>
+              <div class="form-field">
+                <label for="new-impound-date">Impound Date</label>
+                <input id="new-impound-date" name="impoundDate" type="date" />
+              </div>
+              <div class="form-field">
+                <label for="new-impound-lot">Storage Lot</label>
+                <input id="new-impound-lot" name="storageLot" type="text" placeholder="Main Lot · Row 3" />
+              </div>
+            </div>
+            <div class="form-field full-width">
+              <label for="new-impound-notes">Notes</label>
+              <textarea
+                id="new-impound-notes"
+                name="notes"
+                rows="4"
+                placeholder="Include hold reasons, contacts, or release steps"
+              ></textarea>
+            </div>
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="secondary-action" data-modal-dismiss>Cancel</button>
+            <button type="submit" class="primary-action">Create Impound</button>
+          </div>
+        </form>
+      </div>
     </div>
 
     <script src="script.js" type="module"></script>

--- a/script.js
+++ b/script.js
@@ -11,6 +11,9 @@ const impoundFilterInputs = document.querySelectorAll('[data-impound-filter]');
 const impoundSearchFormEl = document.querySelector('#impound-search-form');
 const impoundSearchInputEl = document.querySelector('#impound-search-input');
 const impoundTabButtons = document.querySelectorAll('[data-impound-tab]');
+const newImpoundButton = document.querySelector('#new-impound-button');
+const newImpoundModalEl = document.querySelector('#new-impound-modal');
+const newImpoundFormEl = newImpoundModalEl?.querySelector('form');
 
 const navLinks = document.querySelectorAll('.nav-link[data-view-target]');
 const views = document.querySelectorAll('.view[data-view]');
@@ -41,6 +44,8 @@ const activeThreadStatusEl = document.querySelector('#active-thread-status');
 
 const surveyFilterForm = document.querySelector('#survey-filter-form');
 const surveyListEl = document.querySelector('#survey-list');
+
+let activeModalEl = null;
 
 const statusLabels = {
   waiting: 'Waiting',
@@ -978,6 +983,79 @@ function handleImpoundFilterInput(event) {
   renderImpoundTable();
 }
 
+function openModal(modalEl) {
+  if (!modalEl) return;
+  modalEl.removeAttribute('hidden');
+  modalEl.setAttribute('aria-hidden', 'false');
+  document.body.classList.add('modal-open');
+  activeModalEl = modalEl;
+}
+
+function closeModal(modalEl) {
+  if (!modalEl) return;
+  modalEl.setAttribute('aria-hidden', 'true');
+  modalEl.setAttribute('hidden', '');
+  if (activeModalEl === modalEl) {
+    activeModalEl = null;
+  }
+
+  const hasOpenModal = document.querySelector('.modal:not([hidden])');
+  if (!hasOpenModal) {
+    document.body.classList.remove('modal-open');
+  }
+}
+
+function isModalOpen(modalEl) {
+  return Boolean(modalEl && !modalEl.hasAttribute('hidden'));
+}
+
+function initNewImpoundModal() {
+  if (!newImpoundButton || !newImpoundModalEl) return;
+
+  const dismissElements = newImpoundModalEl.querySelectorAll('[data-modal-dismiss]');
+
+  const handleOpen = () => {
+    openModal(newImpoundModalEl);
+    if (newImpoundFormEl) {
+      newImpoundFormEl.reset();
+      const firstField = newImpoundFormEl.querySelector('input, select, textarea');
+      if (firstField instanceof HTMLElement) {
+        setTimeout(() => firstField.focus(), 0);
+      }
+    }
+  };
+
+  const handleClose = () => {
+    closeModal(newImpoundModalEl);
+    newImpoundFormEl?.reset();
+  };
+
+  newImpoundButton.addEventListener('click', handleOpen);
+
+  dismissElements.forEach((element) => {
+    element.addEventListener('click', handleClose);
+  });
+
+  newImpoundModalEl.addEventListener('click', (event) => {
+    if (event.target === newImpoundModalEl) {
+      handleClose();
+    }
+  });
+
+  document.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape' && isModalOpen(newImpoundModalEl)) {
+      handleClose();
+    }
+  });
+
+  if (newImpoundFormEl) {
+    newImpoundFormEl.addEventListener('submit', (event) => {
+      event.preventDefault();
+      handleClose();
+    });
+  }
+}
+
 function initImpoundModule() {
   if (!impoundTableBodyEl || !impoundDetailEl) return;
 
@@ -1685,6 +1763,7 @@ function init() {
   renderDashboard();
   renderDispatchingModule();
   initImpoundModule();
+  initNewImpoundModal();
   initNavigation();
   initDashboardEvents();
   initDispatchEvents();

--- a/styles.css
+++ b/styles.css
@@ -1258,6 +1258,132 @@ button:disabled,
   text-decoration: none;
 }
 
+body.modal-open {
+  overflow: hidden;
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: grid;
+  place-items: center;
+  padding: 2rem;
+  background: rgba(30, 37, 48, 0.4);
+  backdrop-filter: blur(2px);
+}
+
+.modal[hidden] {
+  display: none;
+}
+
+.modal-dialog {
+  background: #fff;
+  border-radius: 18px;
+  box-shadow: 0 24px 48px rgba(15, 23, 42, 0.18);
+  width: min(720px, 100%);
+  max-height: min(90vh, 760px);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.modal-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  padding: 1.25rem 1.5rem;
+  border-bottom: 1px solid var(--gray-075);
+  gap: 1rem;
+}
+
+.modal-header h2 {
+  font-size: 1.3rem;
+  color: var(--gray-900);
+}
+
+.modal-subtitle {
+  margin-top: 0.25rem;
+  color: var(--gray-400);
+  font-size: 0.9rem;
+}
+
+.modal-close {
+  border: none;
+  background: transparent;
+  font-size: 1.5rem;
+  line-height: 1;
+  color: var(--gray-400);
+  cursor: pointer;
+  padding: 0.25rem;
+  border-radius: 8px;
+  transition: color 0.2s ease, background 0.2s ease;
+}
+
+.modal-close:hover,
+.modal-close:focus {
+  background: var(--gray-050);
+  color: var(--gray-900);
+}
+
+.new-impound-form {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.modal-body {
+  padding: 1.5rem;
+  display: grid;
+  gap: 1.5rem;
+  overflow-y: auto;
+}
+
+.new-impound-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem 1.5rem;
+}
+
+.form-field.full-width {
+  grid-column: 1 / -1;
+}
+
+.modal-footer {
+  padding: 1.25rem 1.5rem 1.5rem;
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  border-top: 1px solid var(--gray-075);
+  background: #fff;
+}
+
+.modal-footer .primary-action {
+  min-width: 150px;
+}
+
+@media (max-width: 600px) {
+  .modal {
+    padding: 1rem;
+  }
+
+  .modal-dialog {
+    border-radius: 14px;
+  }
+
+  .modal-header {
+    padding: 1rem 1.25rem;
+  }
+
+  .modal-body {
+    padding: 1.25rem;
+  }
+
+  .modal-footer {
+    padding: 1rem 1.25rem 1.25rem;
+  }
+}
+
 @media (max-width: 1024px) {
   .topbar {
     padding: 0 1.5rem;


### PR DESCRIPTION
## Summary
- add a dedicated modal and form markup for creating new impounds from the impounds workspace
- introduce modal styling for the pop-out overlay with responsive layout for input fields
- hook up open/close behavior so the New Impound button launches the modal and both cancel controls dismiss it

## Testing
- browser_container.run_playwright_script (Impound modal interaction)


------
https://chatgpt.com/codex/tasks/task_e_68dfdfe684bc8329bfed02c92ae4bd85